### PR TITLE
Use `git rev-list count` to increment build number

### DIFF
--- a/Example/fastlane/Fastfile
+++ b/Example/fastlane/Fastfile
@@ -70,7 +70,7 @@ desc "Release to TestFlight"
     increment_build_number
   end
   
-  private lane :increment_build_number do
+  private_lane :increment_build_number do
     build_number = `git rev-list HEAD --count`.to_i
     increment_build_number(build_number: build_number)
   end


### PR DESCRIPTION
This PR updates the sample app build number based on the `rev-list` count of main.