### PR TITLE
Fix conflicting lane names

### DIFF
--- a/Example/fastlane/Fastfile
+++ b/Example/fastlane/Fastfile
@@ -67,10 +67,10 @@ desc "Release to TestFlight"
       export_method: "app-store"
     )
 
-    increment_build_number
+    increment_build
   end
   
-  private_lane :increment_build_number do
+  private_lane :increment_build do
     build_number = `git rev-list HEAD --count`.to_i
     increment_build_number(build_number: build_number)
   end


### PR DESCRIPTION
**Summary**

- This PR fixes the failure on the release to TestFlight workflow caused by conflicting lane names
