### PR TITLE
Rename smartSelfieRegistration to smartSelfieEnrollment

### DIFF
--- a/Example/SmileIdentity/HomeView.swift
+++ b/Example/SmileIdentity/HomeView.swift
@@ -16,8 +16,8 @@ struct HomeView: View {
                         ProductCell(productImage: "userauth", productName: "SmartSelfie™ \nEnrollment")
                     }
 
-                    .sheet(isPresented: $viewModel.presentSmartSelfieEnrolment,
-                           content: {SmileID.smartSelfieRegistrationScreen(userId: viewModel.generateUserID(),
+                    .sheet(isPresented: $viewModel.presentSmartSelfieEnrollment,
+                           content: {SmileID.smartSelfieEnrollmentScreen(userId: viewModel.generateUserID(),
                                                                            delegate: viewModel)})
                     Button(action: {self.viewModel.handleSmartSelfieAuthTap()}) {
                         ProductCell(productImage: "userauth", productName: "SmartSelfie™ \nAuthentication")

--- a/Example/SmileIdentity/HomeViewController.swift
+++ b/Example/SmileIdentity/HomeViewController.swift
@@ -29,7 +29,7 @@ class HomeViewController: UIViewController, SmartSelfieResultDelegate {
     @IBAction func onSmartSelfieRegistrationTap(_ sender: Any) {
         userID = UUID().uuidString
         currentJob = .smartSelfieEnrollment
-        let smartSelfieRegistrationScreen = SmileID.smartSelfieRegistrationScreen(userId: userID,
+        let smartSelfieRegistrationScreen = SmileID.smartSelfieEnrollmentScreen(userId: userID,
                                                                                         delegate: self)
         cameraVC = UIHostingController(rootView: smartSelfieRegistrationScreen)
         cameraVC?.modalPresentationStyle = .fullScreen

--- a/Example/SmileIdentity/HomeViewModel.swift
+++ b/Example/SmileIdentity/HomeViewModel.swift
@@ -9,18 +9,18 @@ class HomeViewModel: ObservableObject, SmartSelfieResultDelegate {
             switch product {
             case .smartSelfieEnrollment:
                 presentSmartSelfieAuth = false
-                presentSmartSelfieEnrolment = true
+                presentSmartSelfieEnrollment = true
             case .smartSelfieAuthentication:
                 presentSmartSelfieAuth = true
-                presentSmartSelfieEnrolment = false
+                presentSmartSelfieEnrollment = false
             default:
                 presentSmartSelfieAuth = false
-                presentSmartSelfieEnrolment = false
+                presentSmartSelfieEnrollment = false
             }
         }
     }
     @Published var presentSmartSelfieAuth = false
-    @Published var presentSmartSelfieEnrolment = false
+    @Published var presentSmartSelfieEnrollment = false
     @Published var dismissed = false
     @Published var toastMessage = ""
     @Published var showToast = false

--- a/Sources/SmileID.swift
+++ b/Sources/SmileID.swift
@@ -32,7 +32,7 @@ public class SmileID {
         self.theme = theme
     }
 
-    public class func smartSelfieRegistrationScreen(userId: String = "user-\(UUID().uuidString)",
+    public class func smartSelfieEnrollmentScreen(userId: String = "user-\(UUID().uuidString)",
                                                     jobId: String = "job-\(UUID().uuidString)",
                                                     delegate: SmartSelfieResultDelegate)
     -> SmartSelfieInstructionsView {


### PR DESCRIPTION

## Summary

Rename references of smartSelfieRegistration to smartSelfieEnrollment as requested by the Product Team.