### PR TITLE
fix:always use greyscale

### DIFF
--- a/Sources/SmileID/Classes/Helpers/ImageUtils.swift
+++ b/Sources/SmileID/Classes/Helpers/ImageUtils.swift
@@ -21,7 +21,7 @@ class ImageUtils {
                            padding: CGFloat,
                            finalSize: CGSize,
                            screenImageSize: CGSize,
-                           isGreyScale: Bool) -> Data? {
+                           isLivenessImage: Bool) -> Data? {
         guard !faceGeometry.boundingBox.isNaN else { return nil }
 
         CVPixelBufferLockBaseAddress(buffer, CVPixelBufferLockFlags.readOnly)
@@ -41,14 +41,14 @@ class ImageUtils {
                               y: faceGeometry.boundingBox.origin.y,
                               width: faceGeometry.boundingBox.width,
                               height: faceGeometry.boundingBox.height)
-        let finalrect = isGreyScale ?  increaseRect(rect: cropRect, byPercentage: 0.6) : increaseRect(rect: cropRect,
+        let finalrect = isLivenessImage ?  increaseRect(rect: cropRect, byPercentage: 0.6) : increaseRect(rect: cropRect,
                                                                                                       byPercentage: 1)
 
         // crop face from the buffer returned in the above operation and return jpg
         return cropFace(scaledDownBuffer,
                         cropFrame: finalrect,
                         scaleSize: finalSize,
-                        isGreyScale: isGreyScale)
+                        isLivenessImage: isLivenessImage)
     }
 
     private class func increaseRect(rect: CGRect, byPercentage percentage: CGFloat) -> CGRect {
@@ -62,13 +62,8 @@ class ImageUtils {
     private class func cropFace(_ buffer: CVPixelBuffer,
                                 cropFrame: CGRect,
                                 scaleSize: CGSize,
-                                isGreyScale: Bool = true) -> Data? {
+                                isLivenessImage: Bool = true) -> Data? {
         var ciImage = CIImage(cvPixelBuffer: buffer)
-        if isGreyScale {
-            let greyFilter = CIFilter(name: "CIPhotoEffectNoir")
-            greyFilter?.setValue(ciImage, forKey: kCIInputImageKey)
-            ciImage = greyFilter?.outputImage ?? ciImage
-        }
         guard let cgImage = convertCIImageToCGImage(ciImage: ciImage) else { return nil }
         guard let croppedImage = cgImage.cropping(to: cropFrame)?.resize(size: scaleSize) else { return nil }
         return convertCGImageToJPG(cgImage: croppedImage)

--- a/Sources/SmileID/Classes/Helpers/LocalStorage.swift
+++ b/Sources/SmileID/Classes/Helpers/LocalStorage.swift
@@ -27,12 +27,12 @@ class LocalStorage {
             let fileName = filename(for: "liveness")
             let url =  try write(imageData, to: destinationFolder.appendingPathComponent(fileName))
             urls.append(url)
-            return UploadImageInfo(imageTypeId: .livenessPngOrJpgFile,image: fileName)
+            return UploadImageInfo(imageTypeId: .livenessPngOrJpgFile,fileName: fileName)
         })
         let fileName = filename(for: "selfie")
         let previewUrl = try write(previewImage, to: destinationFolder.appendingPathComponent(fileName))
         urls.append(previewUrl)
-        imageInfoArray.append(UploadImageInfo(imageTypeId: .selfiePngOrJpgFile,image: fileName))
+        imageInfoArray.append(UploadImageInfo(imageTypeId: .selfiePngOrJpgFile,fileName: fileName))
         let jsonData = try jsonEncoder.encode(UploadRequest(images: imageInfoArray))
         let jsonUrl = try write(jsonData, to: destinationFolder.appendingPathComponent("info.json"))
         urls.append(jsonUrl)
@@ -44,7 +44,7 @@ class LocalStorage {
     }
 
     private static func filename(for imageType: String) -> String {
-        return "\(imagePrefix)_\(imageType)_\(Date().millisecondsSince1970).jpg"
+        return "\(imagePrefix)\(imageType)_\(Date().millisecondsSince1970).jpg"
     }
 
     static func write(_ data: Data, to url: URL) throws -> URL {
@@ -97,13 +97,13 @@ class LocalStorage {
 fileprivate extension Data {
     var asLivenessImageInfo: UploadImageInfo {
         return UploadImageInfo(imageTypeId: .livenessPngOrJpgBase64,
-                               image: self.base64EncodedString()
+                               fileName: self.base64EncodedString()
         )
     }
 
     var asSelfieImageInfo: UploadImageInfo {
         return UploadImageInfo(imageTypeId: .selfiePngOrJpgBase64,
-                               image: self.base64EncodedString())
+                               fileName: self.base64EncodedString())
     }
 }
 

--- a/Sources/SmileID/Classes/Networking/Models/UploadRequest.swift
+++ b/Sources/SmileID/Classes/Networking/Models/UploadRequest.swift
@@ -12,11 +12,11 @@ public struct UploadRequest: Codable {
 
 public struct UploadImageInfo: Codable {
     var imageTypeId: ImageType
-    var image: String
+    var fileName: String
 
     enum CodingKeys: String, CodingKey {
         case imageTypeId = "image_type_id"
-        case image
+        case fileName = "file_name"
     }
 }
 

--- a/Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureViewModel.swift
@@ -194,7 +194,7 @@ final class SelfieCaptureViewModel: ObservableObject {
                                                      faceGeometry: faceGeometry, padding: 95,
                                                      finalSize: livenessImageSize,
                                                      screenImageSize: viewFinderSize,
-                                                     isGreyScale: false) else { return }
+                                                     isLivenessImage: true) else { return }
             livenessImages.append(image)
             lastCaptureTime = Date().millisecondsSince1970
         }
@@ -211,7 +211,7 @@ final class SelfieCaptureViewModel: ObservableObject {
                                                            faceGeometry: faceGeometry, padding: 200,
                                                            finalSize: selfieImageSize,
                                                            screenImageSize: viewFinderSize,
-                                                           isGreyScale: false) else { return }
+                                                           isLivenessImage: false) else { return }
             lastCaptureTime = Date().millisecondsSince1970
             self.selfieImage = selfieImage
             do {


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

Change liveness images from greyscale to color

## Known Issues

Left the code there, we may need to remove if no longer needed

## Test Instructions

Capture selfie which ever product preferred, uploaded images should all be color

## Screenshot
<img width="174" alt="Screenshot 2023-06-20 at 15 31 45" src="https://github.com/smileidentity/ios-v2/assets/7263902/dd0445f3-c342-4711-9f8c-5d2f9e7ebf59">
<img width="1120" alt="Screenshot 2023-06-20 at 15 32 44" src="https://github.com/smileidentity/ios-v2/assets/7263902/4891ca5a-4742-4724-b098-3f5ee41532c0">



