### PR TITLE
fix:disable reenroll on every job

### DIFF
--- a/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
+++ b/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
@@ -10,7 +10,6 @@ public struct PrepUploadRequest: Codable {
     var sourceSdkVersion = "10.0.0-beta01"
     var timestamp = String(Date().millisecondsSince1970)
     var signature = ""
-    
     /// backend is broken needs these as strings
     /// I've also made this false until we have this properly
     /// documented and done on both android and iOS


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

Fix for making allow new enroll as false by default until properly documented and implemented on both android and iOS

## Known Issues

We should have a discussion about this and documentation etc

## Test Instructions

Enroll a user then authenticate, the test should work on both cases

## Screenshot

If applicable (e.g. UI changes), add screenshots to help explain your work.
