### PR TITLE
Remove push trigger from primary workflow

### DIFF
--- a/.github/workflows/sdk-primary.yml
+++ b/.github/workflows/sdk-primary.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Add Smile Config to Xcode Project
         run: ruby add_smile_config.rb
       - name: Setup Environment
-      - uses: ./.github/actions/setup
+        uses: ./.github/actions/setup
         with:
           xcode: '14.2'
       - name: Build Example app and Run Unit Tests


### PR DESCRIPTION
## Summary

Fixes the issue with failing CI. Danger swift shouldn't be run on pushes to main because it expects an `events.json` which GitHub only sends with the `pull_request` trigger. More info can be found in this [issue](https://github.com/danger/swift/issues/316) 