### PR TITLE
Support overriding localized strings

### DIFF
--- a/Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift
+++ b/Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift
@@ -4,8 +4,4 @@ extension LocalizedStringKey {
     var stringKey: String? {
         Mirror(reflecting: self).children.first(where: { $0.label == "key" })?.value as? String
     }
-
-    func stringValue(locale: Locale = .current) -> String {
-        return SmileIDResourcesHelper.localizedString(for: self.stringKey, locale: locale)
-    }
 }

--- a/Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift
+++ b/Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Encapsulates the bundle and tablename of the Localizeable.strings file to be used within the SDK
+public struct SmileIDLocalizableStrings {
+    /// The bundle where the localizable string is located
+    var bundle: Bundle
+    /// The name of the localizable strings file. Do not include the files `.strings` extension
+    var tablename: String
+}

--- a/Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift
+++ b/Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift
@@ -3,7 +3,12 @@ import Foundation
 /// Encapsulates the bundle and tablename of the Localizeable.strings file to be used within the SDK
 public struct SmileIDLocalizableStrings {
     /// The bundle where the localizable string is located
-    var bundle: Bundle
+    public var bundle: Bundle
     /// The name of the localizable strings file. Do not include the files `.strings` extension
-    var tablename: String
+    public var tablename: String
+
+    public init(bundle: Bundle, tablename: String) {
+        self.bundle = bundle
+        self.tablename = tablename
+    }
 }

--- a/Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift
+++ b/Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift
@@ -2,11 +2,13 @@ import Foundation
 
 /// Encapsulates the bundle and tablename of the Localizeable.strings file to be used within the SDK
 public struct SmileIDLocalizableStrings {
-    /// The bundle where the localizable string is located
     public var bundle: Bundle
-    /// The name of the localizable strings file. Do not include the files `.strings` extension
     public var tablename: String
 
+    /// Initalizes a SmileIDLocalizableStrings
+    /// - Parameters:
+    ///   - bundle: The bundle where the localizable string is located. Usually `Bundle.main`
+    ///   - tablename: The name of the localizable strings file. Do not include the files `.strings` extension
     public init(bundle: Bundle, tablename: String) {
         self.bundle = bundle
         self.tablename = tablename

--- a/Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift
+++ b/Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 public class SmileIDResourcesHelper {
-    /// An internal reference to the images bundle.
-    private static var internalBundle: Bundle?
+
     private static var loadedFonts: [String: String] = [String: String]()
 
     /**
@@ -39,11 +38,13 @@ public class SmileIDResourcesHelper {
     }
 
     /// Get localized strings
-    public static func localizedString(for key: String?,
-                                       locale: Locale = .current) -> String {
+    public static func localizedString(for key: String?) -> String {
 
         if let localizedKey = key {
-            return NSLocalizedString(localizedKey, bundle: bundle, comment: "")
+            return NSLocalizedString(localizedKey,
+                                     tableName: SmileID.localizableStrings?.tablename,
+                                     bundle: SmileID.localizableStrings?.bundle ?? bundle,
+                                     comment: "")
         }
         return ""// we'll return empty I think this will be easier to notice
     }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -27,7 +27,7 @@ public class SmileID {
     public private(set) static var config: Config!
     public private(set) static var useSandbox = true
     public private(set) static var theme: SmileIdTheme = DefaultTheme()
-    static var localizableStrings: SmileIDLocalizableStrings?
+    internal private(set) static var localizableStrings: SmileIDLocalizableStrings?
     @ObservedObject
     internal static var navigationState = NavigationViewModel()
 
@@ -40,16 +40,21 @@ public class SmileID {
     ///   - useSandbox: A boolean to enable the sandbox environment or not
     public class func initialize(config: Config = try! Config(url: Bundle.main.url(forResource: "smile_config",
                                                                                    withExtension: "json")!),
-                                 localizableStrings: SmileIDLocalizableStrings? = nil,
                                  useSandbox: Bool = true) {
         self.config = config
-        self.localizableStrings = localizableStrings
         self.useSandbox = useSandbox
         SmileIDResourcesHelper.registerFonts()
     }
 
     public class func apply(_ theme: SmileIdTheme) {
         self.theme = theme
+    }
+
+    /// Apply localizable strings
+    /// - Parameter localizableStrings: A `SmileIDLocalizableStrings`  used to override all copy used within the SDK.
+    ///   if no value is set, the default copy will be used.
+    public class func apply(_ localizableStrings: SmileIDLocalizableStrings) {
+        self.localizableStrings = localizableStrings
     }
 
     public class func smartSelfieEnrollmentScreen(userId: String = "user-\(UUID().uuidString)",

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -27,12 +27,23 @@ public class SmileID {
     public private(set) static var config: Config!
     public private(set) static var useSandbox = true
     public private(set) static var theme: SmileIdTheme = DefaultTheme()
+    static var localizableStrings: SmileIDLocalizableStrings?
     @ObservedObject
     internal static var navigationState = NavigationViewModel()
+
+    /// This method initilizes SmileID. Invoke this method once in your applicaion lifecylce
+    /// before calling any other SmileID methods.
+    /// - Parameters:
+    ///   - config: The smile config file. If no value is supplied, we check the app's main bundle for a `smile_config.json` file.
+    ///   - localizableStrings: A `SmileIDLocalizableStrings`  used to override all copy used within the SDK.
+    ///   if no value is set, the default copy will be used.
+    ///   - useSandbox: A boolean to enable the sandbox environment or not
     public class func initialize(config: Config = try! Config(url: Bundle.main.url(forResource: "smile_config",
                                                                                    withExtension: "json")!),
+                                 localizableStrings: SmileIDLocalizableStrings? = nil,
                                  useSandbox: Bool = true) {
         self.config = config
+        self.localizableStrings = localizableStrings
         self.useSandbox = useSandbox
         SmileIDResourcesHelper.registerFonts()
     }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -35,8 +35,6 @@ public class SmileID {
     /// before calling any other SmileID methods.
     /// - Parameters:
     ///   - config: The smile config file. If no value is supplied, we check the app's main bundle for a `smile_config.json` file.
-    ///   - localizableStrings: A `SmileIDLocalizableStrings`  used to override all copy used within the SDK.
-    ///   if no value is set, the default copy will be used.
     ///   - useSandbox: A boolean to enable the sandbox environment or not
     public class func initialize(config: Config = try! Config(url: Bundle.main.url(forResource: "smile_config",
                                                                                    withExtension: "json")!),


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

Enables partners supply their own Localizable strings file. This enables them customise all the strings within the SDK.


## Screenshot

The screenshot below shows the SDK supporting an RTL locale

![Simulator Screenshot - iPhone 14 - 2023-09-13 at 15 21 31](https://github.com/smileidentity/ios/assets/4950888/45636afa-fada-43f2-8abb-8bc8b7f0b4ba)
