### PR TITLE
Remove `filename` property from `PrepUploadRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 10.0.0-beta08 (unreleased)
+
+### Removed
+- `filename` property from `PrepUploadRequest`
+
+
 ## 10.0.0-beta07
 
 ### Changed

--- a/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
+++ b/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public struct PrepUploadRequest: Codable {
-    var filename: String = "upload.zip"
     var partnerParams: PartnerParams
     var callbackUrl: String? = ""
     var partnerId = SmileID.config.partnerId
@@ -17,7 +16,6 @@ public struct PrepUploadRequest: Codable {
     var retry = "false" /// backend is broken needs these as strings
 
     enum CodingKeys: String, CodingKey {
-        case filename = "file_name"
         case partnerParams = "partner_params"
         case callbackUrl = "callback_url"
         case partnerId = "smile_client_id"


### PR DESCRIPTION
## Summary

Removes the `file_name` from prep upload, as it is no longer required
