### PR TITLE
Save SmartSelfie Enrollment userId on job completion

### DIFF
--- a/Example/SmileID/EnterUserIDView.swift
+++ b/Example/SmileID/EnterUserIDView.swift
@@ -3,16 +3,14 @@ import SmileID
 
 struct EnterUserIDView: View {
     let onContinue: (_ userId: String) -> Void
-    @State private var userId: String = ""
+    @State private var userId: String
 
     init(
-        initialUserId: String? = nil,
+        initialUserId: String = "",
         onContinue: @escaping (String) -> Void
     ) {
         self.onContinue = onContinue
-        if let initialUserId = initialUserId {
-            userId = initialUserId
-        }
+        userId = initialUserId
     }
 
     var body: some View {

--- a/Example/SmileID/ProductCell.swift
+++ b/Example/SmileID/ProductCell.swift
@@ -4,18 +4,28 @@ import SmileID
 struct ProductCell: View {
     let image: String
     let name: String
+    let onClick: (() -> Void)?
     let content: any View
     @State private var isPresented: Bool = false
 
-    init(image: String, name: String, content: any View) {
+    init(
+        image: String,
+        name: String,
+        onClick: (() -> Void)? = nil,
+        content: any View
+    ) {
         self.image = image
         self.name = name
+        self.onClick = onClick
         self.content = content
     }
 
     public var body: some View {
         Button(
-            action: { isPresented = true },
+            action: {
+                onClick?()
+                isPresented = true
+            },
             label: {
                 VStack(spacing: 24) {
                     Image(image)

--- a/Example/SmileID/SmileTextField.swift
+++ b/Example/SmileID/SmileTextField.swift
@@ -20,6 +20,7 @@ struct SmileTextField: View {
             .font(SmileID.theme.button)
             .padding()
             .background(RoundedRectangle(cornerRadius: 10).fill(backgroundColor))
+            .textFieldStyle(.roundedBorder)
             .foregroundColor(textColor)
             .padding()
     }


### PR DESCRIPTION
## Summary

Since the SmartSelfie Enroll and Auth jobs share the same delegate and since the inital job result is still processing, we can't tell in the delegate what the job type is. This makes a change to define a separate delegate for enroll, so that we can save the userId used for enrollment and pre-populate the smartselfie auth user ID text field with it