### PR TITLE
Biometric KYC

### DIFF
--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		1ED53F6D2A2F28590020BEFB /* SmileTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F632A2F28590020BEFB /* SmileTextField.swift */; };
 		1ED53F6E2A2F28590020BEFB /* ResourcesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F642A2F28590020BEFB /* ResourcesView.swift */; };
 		1ED53F712A2F28590020BEFB /* EnterUserIDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F672A2F28590020BEFB /* EnterUserIDView.swift */; };
-		1ED53F722A2F28590020BEFB /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F682A2F28590020BEFB /* ToggleButton.swift */; };
+		1ED53F722A2F28590020BEFB /* SmileEnvironmentToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F682A2F28590020BEFB /* SmileEnvironmentToggleButton.swift */; };
 		1ED53F732A2F28590020BEFB /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F692A2F28590020BEFB /* HomeView.swift */; };
 		1EFAB3172A375265008E3C13 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		585BE4882AC7748E0091DDD8 /* RestartableTimerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585BE4872AC7748E0091DDD8 /* RestartableTimerTest.swift */; };
@@ -67,7 +67,7 @@
 		1ED53F632A2F28590020BEFB /* SmileTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SmileTextField.swift; sourceTree = "<group>"; };
 		1ED53F642A2F28590020BEFB /* ResourcesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourcesView.swift; sourceTree = "<group>"; };
 		1ED53F672A2F28590020BEFB /* EnterUserIDView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterUserIDView.swift; sourceTree = "<group>"; };
-		1ED53F682A2F28590020BEFB /* ToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
+		1ED53F682A2F28590020BEFB /* SmileEnvironmentToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SmileEnvironmentToggleButton.swift; sourceTree = "<group>"; };
 		1ED53F692A2F28590020BEFB /* HomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		262BF9A8643DF9220FD233E3 /* Pods-SmileID_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SmileID_Example.release.xcconfig"; path = "Target Support Files/Pods-SmileID_Example/Pods-SmileID_Example.release.xcconfig"; sourceTree = "<group>"; };
 		287986BB9E93D632523CC13A /* Pods_SmileID_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SmileID_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -157,7 +157,7 @@
 				1ED53F612A2F28590020BEFB /* ProductCell.swift */,
 				1ED53F642A2F28590020BEFB /* ResourcesView.swift */,
 				1ED53F632A2F28590020BEFB /* SmileTextField.swift */,
-				1ED53F682A2F28590020BEFB /* ToggleButton.swift */,
+				1ED53F682A2F28590020BEFB /* SmileEnvironmentToggleButton.swift */,
 				916E487A2A4057B400C589FE /* smile_config.json */,
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				1E60ED352A29C306002695FF /* AppDelegate.swift */,
@@ -495,7 +495,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1ECAE3872A2F69CD00653FCA /* ToastView.swift in Sources */,
-				1ED53F722A2F28590020BEFB /* ToggleButton.swift in Sources */,
+				1ED53F722A2F28590020BEFB /* SmileEnvironmentToggleButton.swift in Sources */,
 				1ED53F6C2A2F28590020BEFB /* MainView.swift in Sources */,
 				1ED53F6E2A2F28590020BEFB /* ResourcesView.swift in Sources */,
 				1ED53F6A2A2F28590020BEFB /* HomeViewModel.swift in Sources */,

--- a/Example/SmileID/DocumentSelectorViewModel.swift
+++ b/Example/SmileID/DocumentSelectorViewModel.swift
@@ -27,7 +27,6 @@ class DocumentSelectorViewModel: ObservableObject {
         subscriber = SmileID.api.authenticate(request: authRequest)
             .flatMap { authResponse in
                 let productRequest = ProductsConfigRequest(
-                    partnerId: SmileID.config.partnerId,
                     timestamp: authResponse.timestamp,
                     signature: authResponse.signature
                 )

--- a/Example/SmileID/EnterUserIDView.swift
+++ b/Example/SmileID/EnterUserIDView.swift
@@ -34,7 +34,7 @@ struct EnterUserIDView: View {
 }
 
 @available(iOS 14.0, *)
-struct EnterUserIDView_Previews: PreviewProvider {
+private struct EnterUserIDView_Previews: PreviewProvider {
     static var previews: some View {
         EnterUserIDView(initialUserId: "initialValue") { _ in }
     }

--- a/Example/SmileID/HomeView.swift
+++ b/Example/SmileID/HomeView.swift
@@ -42,7 +42,7 @@ struct HomeView: View {
                         ),
                         ProductCell(
                             image: "document",
-                            name: "Document Verification",
+                            name: "\nDocument Verification",
                             content: DocumentVerificationWithSelector(delegate: viewModel)
                         ),
                         ProductCell(
@@ -78,7 +78,7 @@ struct HomeView: View {
                 }
                 .padding()
                 .navigationBarTitle(Text("Smile ID"), displayMode: .inline)
-                .navigationBarItems(trailing: ToggleButton())
+                .navigationBarItems(trailing: SmileEnvironmentToggleButton())
                 .background(SmileID.theme.backgroundLight.edgesIgnoringSafeArea(.all))
         }
     }
@@ -199,7 +199,7 @@ private struct MyVerticalGrid: View {
     var body: some View {
         GeometryReader { geo in
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
                     let numRows = (items.count + maxColumns - 1) / maxColumns
                     ForEach(0..<numRows) { rowIndex in
                         HStack(spacing: 16) {
@@ -223,7 +223,7 @@ private struct MyVerticalGrid: View {
 }
 
 @available(iOS 14.0, *)
-struct HomeView_Previews: PreviewProvider {
+private struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         let _ = SmileID.initialize(
             config: Config(

--- a/Example/SmileID/HomeView.swift
+++ b/Example/SmileID/HomeView.swift
@@ -21,51 +21,54 @@ struct HomeView: View {
                         ProductCell(
                             image: "userauth",
                             name: "SmartSelfie™ Enrollment",
-                            onClick: { smartSelfieEnrollmentUserId = generateUserId() }
-                        ) {
-                            SmileID.smartSelfieEnrollmentScreen(
-                                userId: smartSelfieEnrollmentUserId,
-                                allowAgentMode: true,
-                                delegate: SmartSelfieEnrollmentDelegate(
+                            onClick: { smartSelfieEnrollmentUserId = generateUserId() },
+                            content: {
+                                SmileID.smartSelfieEnrollmentScreen(
                                     userId: smartSelfieEnrollmentUserId,
-                                    onEnrollmentSuccess: viewModel.onSmartSelfieEnrollment,
-                                    onError: viewModel.didError
+                                    allowAgentMode: true,
+                                    delegate: SmartSelfieEnrollmentDelegate(
+                                        userId: smartSelfieEnrollmentUserId,
+                                        onEnrollmentSuccess: viewModel.onSmartSelfieEnrollment,
+                                        onError: viewModel.didError
+                                    )
                                 )
-                            )
-                        },
+                            }
+                        ),
                         ProductCell(
                             image: "userauth",
-                            name: "SmartSelfie™ Authentication"
-                        ) {
-                            SmartSelfieAuthWithUserIdEntry(
-                                initialUserId: smartSelfieEnrollmentUserId,
-                                delegate: viewModel
-                            )
-                        },
+                            name: "SmartSelfie™ Authentication",
+                            content: {
+                                SmartSelfieAuthWithUserIdEntry(
+                                    initialUserId: smartSelfieEnrollmentUserId,
+                                    delegate: viewModel
+                                )
+                            }
+                        ),
                         ProductCell(
                             image: "document",
-                            name: "\nDocument Verification"
-                        ) {
-                            DocumentVerificationWithSelector(delegate: viewModel)
-                        },
+                            name: "\nDocument Verification",
+                            content: { DocumentVerificationWithSelector(delegate: viewModel) }
+                        ),
                         ProductCell(
                             image: "document",
-                            name: "Enhanced Document Verification"
-                        ) {
-                            EnhancedDocumentVerificationWithSelector(delegate: viewModel)
-                        },
+                            name: "Enhanced Document Verification",
+                            content: {
+                                EnhancedDocumentVerificationWithSelector(delegate: viewModel)
+                            }
+                        ),
                         ProductCell(
                             image: "biometric",
-                            name: "Biometric KYC"
-                        ) {
-                            SmileID.biometricKycScreen(
-                                partnerIcon: UIImage(named: "SmileLogo")!,
-                                partnerName: "Smile ID",
-                                productName: "ID",
-                                partnerPrivacyPolicy: URL(string: "https://usesmileid.com")!,
-                                delegate: viewModel
-                            )
-                        }
+                            name: "Biometric KYC",
+                            content: {
+                                SmileID.biometricKycScreen(
+                                    partnerIcon: UIImage(named: "SmileLogo")!,
+                                    partnerName: "Smile ID",
+                                    productName: "ID",
+                                    partnerPrivacyPolicy: URL(string: "https://usesmileid.com")!,
+                                    delegate: viewModel
+                                )
+                            }
+                        )
                     ].map { AnyView($0) }
                 )
 

--- a/Example/SmileID/HomeView.swift
+++ b/Example/SmileID/HomeView.swift
@@ -21,8 +21,9 @@ struct HomeView: View {
                         ProductCell(
                             image: "userauth",
                             name: "SmartSelfie™ Enrollment",
-                            onClick: { smartSelfieEnrollmentUserId = generateUserId() },
-                            content: SmileID.smartSelfieEnrollmentScreen(
+                            onClick: { smartSelfieEnrollmentUserId = generateUserId() }
+                        ) {
+                            SmileID.smartSelfieEnrollmentScreen(
                                 userId: smartSelfieEnrollmentUserId,
                                 allowAgentMode: true,
                                 delegate: SmartSelfieEnrollmentDelegate(
@@ -31,36 +32,40 @@ struct HomeView: View {
                                     onError: viewModel.didError
                                 )
                             )
-                        ),
+                        },
                         ProductCell(
                             image: "userauth",
-                            name: "SmartSelfie™ Authentication",
-                            content: SmartSelfieAuthWithUserIdEntry(
+                            name: "SmartSelfie™ Authentication"
+                        ) {
+                            SmartSelfieAuthWithUserIdEntry(
                                 initialUserId: smartSelfieEnrollmentUserId,
                                 delegate: viewModel
                             )
-                        ),
+                        },
                         ProductCell(
                             image: "document",
-                            name: "\nDocument Verification",
-                            content: DocumentVerificationWithSelector(delegate: viewModel)
-                        ),
+                            name: "\nDocument Verification"
+                        ) {
+                            DocumentVerificationWithSelector(delegate: viewModel)
+                        },
                         ProductCell(
                             image: "document",
-                            name: "Enhanced Document Verification",
-                            content: EnhancedDocumentVerificationWithSelector(delegate: viewModel)
-                        ),
+                            name: "Enhanced Document Verification"
+                        ) {
+                            EnhancedDocumentVerificationWithSelector(delegate: viewModel)
+                        },
                         ProductCell(
                             image: "biometric",
-                            name: "Biometric KYC",
-                            content: SmileID.biometricKycScreen(
+                            name: "Biometric KYC"
+                        ) {
+                            SmileID.biometricKycScreen(
                                 partnerIcon: UIImage(named: "SmileLogo")!,
                                 partnerName: "Smile ID",
                                 productName: "ID",
                                 partnerPrivacyPolicy: URL(string: "https://usesmileid.com")!,
                                 delegate: viewModel
                             )
-                        )
+                        }
                     ].map { AnyView($0) }
                 )
 

--- a/Example/SmileID/HomeView.swift
+++ b/Example/SmileID/HomeView.swift
@@ -54,7 +54,6 @@ struct HomeView: View {
                             image: "biometric",
                             name: "Biometric KYC",
                             content: SmileID.biometricKycScreen(
-                                idInfo: IdInfo(country: "NG", idType: "PASSPORT"),
                                 partnerIcon: UIImage(named: "SmileLogo")!,
                                 partnerName: "Smile ID",
                                 productName: "Consent Demo",

--- a/Example/SmileID/HomeView.swift
+++ b/Example/SmileID/HomeView.swift
@@ -56,7 +56,7 @@ struct HomeView: View {
                             content: SmileID.biometricKycScreen(
                                 partnerIcon: UIImage(named: "SmileLogo")!,
                                 partnerName: "Smile ID",
-                                productName: "Consent Demo",
+                                productName: "ID",
                                 partnerPrivacyPolicy: URL(string: "https://usesmileid.com")!,
                                 delegate: viewModel
                             )

--- a/Example/SmileID/MainView.swift
+++ b/Example/SmileID/MainView.swift
@@ -32,7 +32,7 @@ struct MainView: View {
 }
 
 @available(iOS 14.0, *)
-struct MainView_Previews: PreviewProvider {
+private struct MainView_Previews: PreviewProvider {
     static var previews: some View {
         MainView()
     }

--- a/Example/SmileID/ProductCell.swift
+++ b/Example/SmileID/ProductCell.swift
@@ -5,14 +5,14 @@ struct ProductCell: View {
     let image: String
     let name: String
     let onClick: (() -> Void)?
-    let content: any View
+    @ViewBuilder let content: () -> any View
     @State private var isPresented: Bool = false
 
     init(
         image: String,
         name: String,
         onClick: (() -> Void)? = nil,
-        content: any View
+        @ViewBuilder content: @escaping () -> any View
     ) {
         self.image = image
         self.name = name
@@ -41,7 +41,7 @@ struct ProductCell: View {
                     .frame(maxWidth: .infinity)
                     .background(SmileID.theme.accent)
                     .cornerRadius(8)
-                    .sheet(isPresented: $isPresented, content: { AnyView(content) })
+                    .sheet(isPresented: $isPresented, content: { AnyView(content()) })
             }
         )
     }
@@ -52,7 +52,7 @@ private struct ProductCell_Previews: PreviewProvider {
         ProductCell(
             image: "userauth",
             name: "SmartSelfie™ Authentication",
-            content: Text("Hello")
+            content: { Text("Hello") }
         )
     }
 }

--- a/Example/SmileID/ProductCell.swift
+++ b/Example/SmileID/ProductCell.swift
@@ -47,7 +47,7 @@ struct ProductCell: View {
     }
 }
 
-struct ProductCell_Previews: PreviewProvider {
+private struct ProductCell_Previews: PreviewProvider {
     static var previews: some View {
         ProductCell(
             image: "userauth",

--- a/Example/SmileID/ResourcesView.swift
+++ b/Example/SmileID/ResourcesView.swift
@@ -97,7 +97,7 @@ struct AboutUsCell: View {
     }
 }
 
-struct ResourcesView_Previews: PreviewProvider {
+private struct ResourcesView_Previews: PreviewProvider {
     static var previews: some View {
         ResourcesView()
     }

--- a/Example/SmileID/SmileEnvironmentToggleButton.swift
+++ b/Example/SmileID/SmileEnvironmentToggleButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import SmileID
 
-struct ToggleButton: View {
+struct SmileEnvironmentToggleButton: View {
     @State private var isProduction: Bool = false
 
     var body: some View {
@@ -30,8 +30,8 @@ extension Color {
     static let amberColor = Color(red: 45 / 255, green: 43 / 255, blue: 42 / 255)
 }
 
-struct ToggleButton_Previews: PreviewProvider {
+private struct SmileEnvironmentToggleButton_Previews: PreviewProvider {
     static var previews: some View {
-        ToggleButton()
+        SmileEnvironmentToggleButton()
     }
 }

--- a/Example/SmileID/SmileTextField.swift
+++ b/Example/SmileID/SmileTextField.swift
@@ -24,7 +24,7 @@ struct SmileTextField: View {
     }
 }
 
-struct SmileTextField_Previews: PreviewProvider {
+private struct SmileTextField_Previews: PreviewProvider {
     static var previews: some View {
         SmileTextField(field: .constant("Some user"))
     }

--- a/Example/SmileID/SmileTextField.swift
+++ b/Example/SmileID/SmileTextField.swift
@@ -11,8 +11,6 @@ struct SmileTextField: View {
     // The @State Object
     @Binding var field: String
 
-    // A custom variable for a "TextField"
-    @State var isHighlighted = false
     var placeholder = ""
 
     var body: some View {

--- a/Sources/SmileID/Classes/BiometricKYC/IdInfoInputScreen.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/IdInfoInputScreen.swift
@@ -113,7 +113,7 @@ struct IdInfoInputScreen: View {
 }
 
 @available(iOS 14.0, *)
-struct IdInfoInputScreen_Previews: PreviewProvider {
+private struct IdInfoInputScreen_Previews: PreviewProvider {
     static var previews: some View {
         IdInfoInputScreen(
             selectedCountry: "US",

--- a/Sources/SmileID/Classes/BiometricKYC/IdInfoInputScreen.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/IdInfoInputScreen.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// Allows user to enter ID info. Requires that the user has already selected a country and ID type.
+/// It does not allow the entry of any whitespace. Dates are selected using a `DatePicker`, and
+/// everything else using a `TextField`
+///
+/// - Parameters:
+///  - selectedCountry: The country code of the selected country
+///  - selectedIdType: The ID type code of the selected ID type
+///  - header: The header to display at the top of the screen
+///  - requiredFields: The fields that the user must enter
+///  - onResult: The callback to invoke when the user taps the Continue button. The result will be
+///  delivered as an `IdInfo` object.
+struct IdInfoInputScreen: View {
+    let header: String
+    let onResult: (IdInfo) -> Void
+    let dateFormatter = DateFormatter()
+    @ObservedObject var viewModel: IdInfoInputViewModel
+
+    init(
+        selectedCountry: String,
+        selectedIdType: String,
+        header: String,
+        requiredFields: [RequiredField],
+        onResult: @escaping (IdInfo) -> Void
+    ) {
+        self.header = header
+        self.onResult = onResult
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        viewModel = IdInfoInputViewModel(
+            selectedCountry: selectedCountry,
+            selectedIdType: selectedIdType,
+            requiredFields: requiredFields
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .center) {
+            Form {
+                Section(
+                    header: Text(header)
+                        .font(SmileID.theme.header2)
+                        .foregroundColor(SmileID.theme.onLight)
+                        .padding(.vertical, 8)
+                ) {
+                    let sortedKeys = viewModel.inputs.keys.sorted(by: RequiredField.sorter)
+                    ForEach(sortedKeys, id: \.self) { key in
+                        let localizedLabel = SmileIDResourcesHelper.localizedString(
+                            for: key.inputField.label
+                        )
+                        VStack(alignment: .leading) {
+                            if key == .dateOfBirth {
+                                let valueBinding = Binding<Date>(
+                                    get: {
+                                        let value = viewModel.inputs[key] ?? ""
+                                        return dateFormatter.date(from: value) ?? Date()
+                                    },
+                                    set: {
+                                        viewModel.inputs[key] = dateFormatter.string(from: $0)
+                                    }
+                                )
+                                DatePicker(
+                                    localizedLabel,
+                                    selection: valueBinding,
+                                    in: ...Date(),
+                                    displayedComponents: [.date]
+                                )
+                                    .font(SmileID.theme.button)
+                                    .foregroundColor(SmileID.theme.onLight)
+                                    .padding(4)
+                            } else {
+                                let valueBinding = Binding<String>(
+                                    get: { viewModel.inputs[key] ?? "Error" },
+                                    set: { newValue in
+                                        viewModel.inputs[key] = newValue.filter { !$0.isWhitespace }
+                                    }
+                                )
+                                Text(localizedLabel)
+                                    .font(SmileID.theme.button)
+                                    .foregroundColor(SmileID.theme.onLight)
+                                    .padding(4)
+                                TextField(localizedLabel, text: valueBinding)
+                                    .keyboardType(key.inputField.keyboardType)
+                                    .disableAutocorrection(true)
+                                    .autocapitalization(.none)
+                                    .textFieldStyle(.roundedBorder)
+                                    .foregroundColor(SmileID.theme.onLight)
+                                    .padding(4)
+                            }
+                        }
+                    }
+                }
+            }
+                .background(SmileID.theme.backgroundLight)
+
+            Button(
+                action: { onResult(viewModel.currentIdInfo) },
+                label: {
+                    Text(SmileIDResourcesHelper.localizedString(for: "Confirmation.Continue"))
+                        .padding(16)
+                        .font(SmileID.theme.button)
+                        .frame(maxWidth: .infinity)
+                }
+            )
+                .disabled(!viewModel.isContinueEnabled)
+                .background(!viewModel.isContinueEnabled ? Color.gray : SmileID.theme.accent)
+                .foregroundColor(SmileID.theme.onDark)
+                .cornerRadius(60)
+                .frame(maxWidth: .infinity)
+                .padding()
+        }.frame(maxWidth: .infinity)
+    }
+}
+
+@available(iOS 14.0, *)
+struct IdInfoInputScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        IdInfoInputScreen(
+            selectedCountry: "US",
+            selectedIdType: "Driver's License",
+            header: "Enter ID Info",
+            requiredFields: [.idNumber, .firstName, .lastName, .dateOfBirth, .bankCode],
+            onResult: { _ in }
+        )
+    }
+}

--- a/Sources/SmileID/Classes/BiometricKYC/IdInfoInputViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/IdInfoInputViewModel.swift
@@ -1,0 +1,78 @@
+class IdInfoInputViewModel: ObservableObject {
+    // MARK: - Input Properties
+    private let selectedCountry: String
+    private let selectedIdType: String
+
+    // MARK: - UI Properties
+    @Published var inputs: [RequiredField: String] = [:]
+
+    // MARK: - Other Properties
+    var isContinueEnabled: Bool { inputs.values.allSatisfy { !$0.isEmpty } }
+
+    var currentIdInfo: IdInfo {
+        IdInfo(
+            country: selectedCountry,
+            idType: selectedIdType,
+            idNumber: inputs[.idNumber],
+            firstName: inputs[.firstName],
+            lastName: inputs[.lastName],
+            dob: inputs[.dateOfBirth],
+            bankCode: inputs[.bankCode],
+            entered: true
+        )
+    }
+
+    init(
+        selectedCountry: String,
+        selectedIdType: String,
+        requiredFields: [RequiredField]
+    ) {
+        self.selectedCountry = selectedCountry
+        self.selectedIdType = selectedIdType
+
+        // We've already asked for these fields as input on the ID Selection screen
+        let ignoredFields: [RequiredField] = [
+            .country,
+            .idType,
+            .userId,
+            .jobId,
+        ]
+        requiredFields
+            .filter { !ignoredFields.contains($0) }
+            .forEach { inputs[$0] = "" }
+    }
+}
+
+/// An extension to RequiredField which provides a mapping to the input field label and keyboard
+// type
+extension RequiredField {
+    struct InputField {
+        let key: RequiredField
+        let label: String
+        let keyboardType: UIKeyboardType
+    }
+    var inputField: InputField {
+        switch self {
+        case .idNumber:
+            return InputField(key: self, label: "IdInfo.IdNumber", keyboardType: .asciiCapable)
+        case .firstName:
+            return InputField(key: self, label: "IdInfo.FirstName", keyboardType: .default)
+        case .lastName:
+            return InputField(key: self, label: "IdInfo.LastName", keyboardType: .default)
+        case .dateOfBirth:
+            return InputField(key: self, label: "IdInfo.DOB", keyboardType: .default)
+        case .day:
+            return InputField(key: self, label: "IdInfo.Day", keyboardType: .numberPad)
+        case .month:
+            return InputField(key: self, label: "IdInfo.Month", keyboardType: .numberPad)
+        case .year:
+            return InputField(key: self, label: "IdInfo.Year", keyboardType: .numberPad)
+        case .bankCode:
+            return InputField(key: self, label: "IdInfo.BankCode", keyboardType: .numberPad)
+        case .citizenship:
+            return InputField(key: self, label: "IdInfo.Citizenship", keyboardType: .default)
+        default:
+            return InputField(key: self, label: self.rawValue, keyboardType: .default)
+        }
+    }
+}

--- a/Sources/SmileID/Classes/BiometricKYC/IdInfoInputViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/IdInfoInputViewModel.swift
@@ -30,8 +30,17 @@ class IdInfoInputViewModel: ObservableObject {
         self.selectedCountry = selectedCountry
         self.selectedIdType = selectedIdType
 
-        // We've already asked for these fields as input on the ID Selection screen
-        let ignoredFields: [RequiredField] = [.country, .idType, .userId, .jobId]
+        // We've already asked for these fields as input on the ID Selection screen. Day/month/year
+        // are ignored because they are duplicated by the dob field
+        let ignoredFields: [RequiredField] = [
+            .country,
+            .idType,
+            .userId,
+            .jobId,
+            .day,
+            .month,
+            .year
+        ]
         requiredFields
             .filter { !ignoredFields.contains($0) }
             .forEach { inputs[$0] = "" }
@@ -46,6 +55,7 @@ extension RequiredField {
         let label: String
         let keyboardType: UIKeyboardType
     }
+
     var inputField: InputField {
         switch self {
         case .idNumber:

--- a/Sources/SmileID/Classes/BiometricKYC/IdInfoInputViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/IdInfoInputViewModel.swift
@@ -31,12 +31,7 @@ class IdInfoInputViewModel: ObservableObject {
         self.selectedIdType = selectedIdType
 
         // We've already asked for these fields as input on the ID Selection screen
-        let ignoredFields: [RequiredField] = [
-            .country,
-            .idType,
-            .userId,
-            .jobId,
-        ]
+        let ignoredFields: [RequiredField] = [.country, .idType, .userId, .jobId]
         requiredFields
             .filter { !ignoredFields.contains($0) }
             .forEach { inputs[$0] = "" }
@@ -44,7 +39,7 @@ class IdInfoInputViewModel: ObservableObject {
 }
 
 /// An extension to RequiredField which provides a mapping to the input field label and keyboard
-// type
+/// type
 extension RequiredField {
     struct InputField {
         let key: RequiredField

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
@@ -14,7 +14,7 @@ struct OrchestratedBiometricKycScreen: View {
     let delegate: BiometricKycResultDelegate
     @ObservedObject private var viewModel: OrchestratedBiometricKycViewModel
 
-    @State private var selectedCountry: CountryInfo? = nil
+    @State private var selectedCountry: CountryInfo?
 
     init(
         idInfo: IdInfo?,

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
@@ -1,0 +1,146 @@
+import Combine
+import SwiftUI
+
+struct OrchestratedBiometricKycScreen: View {
+    let userId: String
+    let jobId: String
+    let partnerIcon: UIImage
+    let partnerName: String
+    let productName: String
+    let partnerPrivacyPolicy: URL
+    let showInstructions: Bool
+    let showAttribution: Bool
+    let allowAgentMode: Bool
+    let delegate: BiometricKycResultDelegate
+    @ObservedObject private var viewModel: OrchestratedBiometricKycViewModel
+
+    @State private var selectedCountry: CountryInfo? = nil
+
+    init(
+        idInfo: IdInfo?,
+        userId: String,
+        jobId: String,
+        partnerIcon: UIImage,
+        partnerName: String,
+        productName: String,
+        partnerPrivacyPolicy: URL,
+        showInstructions: Bool,
+        showAttribution: Bool,
+        allowAgentMode: Bool,
+        delegate: BiometricKycResultDelegate
+    ) {
+        self.userId = userId
+        self.jobId = jobId
+        self.partnerIcon = partnerIcon
+        self.partnerName = partnerName
+        self.productName = productName
+        self.partnerPrivacyPolicy = partnerPrivacyPolicy
+        self.showInstructions = showInstructions
+        self.showAttribution = showAttribution
+        self.allowAgentMode = allowAgentMode
+        self.delegate = delegate
+        viewModel = OrchestratedBiometricKycViewModel(userId: userId, jobId: jobId, idInfo: idInfo)
+    }
+
+    var body: some View {
+        switch viewModel.step {
+        case .loading(let messageKey):
+            VStack {
+                ActivityIndicator(isAnimating: true).padding()
+                Text(SmileIDResourcesHelper.localizedString(for: messageKey))
+                    .font(SmileID.theme.body)
+                    .foregroundColor(SmileID.theme.onLight)
+            }
+                .frame(maxWidth: .infinity)
+        case .idTypeSelection(let countryList):
+            SearchableDropdownSelector(
+                items: countryList,
+                selectedItem: selectedCountry,
+                itemDisplayName: { $0.name },
+                onItemSelected: { selectedCountry = $0 }
+            )
+            if let selectedCountry = selectedCountry {
+                RadioGroupSelector(
+                    title: SmileIDResourcesHelper.localizedString(for: "BiometricKYC.SelectIdType"),
+                    items: selectedCountry.availableIdTypes,
+                    itemDisplayName: { $0.label },
+                    onItemSelected: { idType in
+                        viewModel.onIdTypeSelected(
+                            country: selectedCountry.countryCode,
+                            idType: idType.idTypeKey,
+                            requiredFields: idType.requiredFields ?? []
+                        )
+                    }
+                )
+            }
+        case .consent(let country, let idType, let requiredFields):
+            OrchestratedConsentScreen(
+                partnerIcon: partnerIcon,
+                partnerName: partnerName,
+                productName: productName,
+                partnerPrivacyPolicy: partnerPrivacyPolicy,
+                showAttribution: showAttribution,
+                onConsentGranted: {
+                    viewModel.onConsentGranted(
+                        country: country,
+                        idType: idType,
+                        requiredFields: requiredFields)
+                },
+                onConsentDenied: { delegate.didError(error: SmileIDError.consentDenied) }
+            )
+        case .idInput(let country, let idType, let requiredFields):
+            IdInfoInputScreen(
+                selectedCountry: country,
+                selectedIdType: idType,
+                header: SmileIDResourcesHelper.localizedString(
+                    for: "BiometricKYC.EnterIdInfoTitle"
+                ),
+                requiredFields: requiredFields,
+                onResult: viewModel.onIdFieldsEntered
+            ).frame(maxWidth: .infinity)
+        case .selfie:
+            SelfieCaptureView(
+                viewModel: SelfieCaptureViewModel(
+                    userId: userId,
+                    jobId: jobId,
+                    isEnroll: false,
+                    shouldSubmitJob: false,
+                    // imageCaptureDelegate is just for image capture, not job result
+                    imageCaptureDelegate: viewModel
+                ),
+                delegate: nil
+            )
+        case .processing(let state):
+            ProcessingScreen(
+                processingState: state,
+                inProgressTitle: SmileIDResourcesHelper.localizedString(
+                    for: "BiometricKYC.Processing.Title"
+                ),
+                inProgressSubtitle: SmileIDResourcesHelper.localizedString(
+                    for: "BiometricKYC.Processing.Subtitle"
+                ),
+                inProgressIcon: SmileIDResourcesHelper.DocumentProcessing,
+                successTitle: SmileIDResourcesHelper.localizedString(
+                    for: "BiometricKYC.Success.Title"
+                ),
+                successSubtitle: SmileIDResourcesHelper.localizedString(
+                    for: "BiometricKYC.Success.Subtitle"
+                ),
+                successIcon: SmileIDResourcesHelper.CheckBold,
+                errorTitle: SmileIDResourcesHelper.localizedString(for: "BiometricKYC.Error.Title"),
+                errorSubtitle: SmileIDResourcesHelper.localizedString(
+                    for: "BiometricKYC.Error.Subtitle"
+                ),
+                errorIcon: SmileIDResourcesHelper.Scan,
+                continueButtonText: SmileIDResourcesHelper.localizedString(
+                    for: "Confirmation.Continue"
+                ),
+                onContinue: { viewModel.onFinished(delegate: delegate) },
+                retryButtonText: SmileIDResourcesHelper.localizedString(for: "Confirmation.Retry"),
+                onRetry: viewModel.onRetry,
+                closeButtonText: SmileIDResourcesHelper.localizedString(for: "Confirmation.Close"),
+                onClose: { viewModel.onFinished(delegate: delegate) }
+            )
+        }
+    }
+}

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -1,0 +1,244 @@
+import Combine
+
+internal enum BiometricKycStep {
+    case loading(messageKey: String)
+    case idTypeSelection([CountryInfo])
+    case consent(country: String, idType: String, requiredFields: [RequiredField])
+    case idInput(country: String, idType: String, requiredFields: [RequiredField])
+    case selfie
+    case processing(ProcessingState)
+}
+
+internal class OrchestratedBiometricKycViewModel: ObservableObject, SelfieImageCaptureDelegate {
+    // MARK: - Input Properties
+    private let userId: String
+    private let jobId: String
+    private var idInfo: IdInfo?
+
+    // MARK: - Other Properties
+    private var error: Error?
+    private var selfieCaptureResultStore: SelfieCaptureResultStore?
+    private var jobStatusResponse: BiometricKycJobStatusResponse?
+
+    // MARK: - UI Properties
+    @Published @MainActor private (set) var step: BiometricKycStep = .loading(
+        messageKey: "BiometricKYC.Loading.IdTypes"
+    )
+
+    init(userId: String, jobId: String, idInfo: IdInfo?) {
+        self.userId = userId
+        self.jobId = jobId
+        self.idInfo = idInfo
+        if let idInfo = idInfo {
+            guard let idType = idInfo.idType else {
+                fatalError("You are expected to pass in the idType if you pass in idInfo")
+            }
+            // On this code path, we don't need to load services, ever, at all
+            loadConsent(country: idInfo.country, idType: idType, requiredFields: [])
+        } else {
+            loadIdTypes()
+        }
+    }
+
+    private func loadIdTypes() {
+        let authRequest = AuthenticationRequest(
+            jobType: .biometricKyc,
+            enrollment: false,
+            jobId: jobId,
+            userId: userId
+        )
+        DispatchQueue.main.async {
+            self.step = .loading(messageKey: "BiometricKYC.Loading.IdTypes")
+        }
+        Task {
+            do {
+                let authResponse = try await SmileID.api.authenticate(request: authRequest).async()
+                let productsConfigRequest = ProductsConfigRequest(
+                    timestamp: authResponse.timestamp,
+                    signature: authResponse.signature
+                )
+                let productsConfigResponse = try await SmileID.api.getProductsConfig(
+                    request: productsConfigRequest
+                ).async()
+                let supportedCountries = productsConfigResponse.idSelection.biometricKyc
+                let servicesResponse = try await SmileID.api.getServices().async()
+                let servicesCountryInfo = servicesResponse.hostedWeb.biometricKyc
+                // sort by country name
+                let countryList = servicesCountryInfo
+                    .filter { supportedCountries.keys.contains($0.countryCode) }
+                    .sorted { $0.name < $1.name }
+                DispatchQueue.main.async { self.step = .idTypeSelection(countryList) }
+            } catch {
+                print("Error loading id types: \(error)")
+                self.error = error
+                DispatchQueue.main.async { self.step = .processing(.error) }
+            }
+        }
+    }
+
+    private func loadConsent(
+        country: String,
+        idType: String,
+        requiredFields: [RequiredField]
+    ) {
+        let authRequest = AuthenticationRequest(
+            jobType: .biometricKyc,
+            enrollment: false,
+            jobId: jobId,
+            userId: userId,
+            country: country,
+            idType: idType
+        )
+        DispatchQueue.main.async {
+            self.step = .loading(messageKey: "BiometricKYC.Loading.Consent")
+        }
+        Task {
+            do {
+                let authResponse = try await SmileID.api.authenticate(request: authRequest).async()
+                if authResponse.consentInfo?.consentRequired == true {
+                    DispatchQueue.main.async {
+                        self.step = .consent(
+                            country: country,
+                            idType: idType,
+                            requiredFields: requiredFields
+                        )
+                    }
+                } else {
+                    // We don't need consent. Proceed forward as if consent has already been granted
+                    onConsentGranted(
+                        country: country,
+                        idType: idType,
+                        requiredFields: requiredFields
+                    )
+                }
+            } catch {
+                print("Error loading consent: \(error)")
+                self.error = error
+                DispatchQueue.main.async { self.step = .processing(.error) }
+            }
+        }
+    }
+
+    func onIdTypeSelected(country: String, idType: String, requiredFields: [RequiredField]) {
+        loadConsent(country: country, idType: idType, requiredFields: requiredFields)
+    }
+
+    func onConsentGranted(country: String, idType: String, requiredFields: [RequiredField]) {
+        // If idInfo is already set, it was passed in, so we skip straight to selfie capture -- the
+        // partner is required to pass in all required inputs
+        if let _ = idInfo {
+            DispatchQueue.main.async { self.step = .selfie }
+        } else {
+            DispatchQueue.main.async {
+                self.step = .idInput(
+                    country: country,
+                    idType: idType,
+                    requiredFields: requiredFields
+                )
+            }
+        }
+    }
+
+    func onIdFieldsEntered(idInfo: IdInfo) {
+        self.idInfo = idInfo
+        DispatchQueue.main.async { self.step = .selfie }
+    }
+
+    func didCapture(selfie: Data, livenessImages: [Data]) {
+        selfieCaptureResultStore = try? LocalStorage.saveSelfieImages(
+            selfieImage: selfie,
+            livenessImages: livenessImages
+        )
+        if let selfieCaptureResultStore = selfieCaptureResultStore {
+            submitJob(selfieCaptureResultStore: selfieCaptureResultStore)
+        } else {
+            error = SmileIDError.unknown("Failed to save selfie capture result")
+            DispatchQueue.main.async { self.step = .processing(.error) }
+        }
+    }
+
+    func onRetry() {
+        if idInfo == nil {
+            loadIdTypes()
+        } else if selfieCaptureResultStore == nil {
+            DispatchQueue.main.async { self.step = .selfie }
+        } else {
+            submitJob(selfieCaptureResultStore: selfieCaptureResultStore!)
+        }
+    }
+
+    func onFinished(delegate: BiometricKycResultDelegate) {
+        if let jobStatusResponse = jobStatusResponse,
+           let selfieCaptureResultStore = selfieCaptureResultStore {
+            delegate.didSucceed(
+                selfieImage: selfieCaptureResultStore.selfie,
+                livenessImages: selfieCaptureResultStore.livenessImages,
+                jobStatusResponse: jobStatusResponse
+            )
+        } else if let error = error {
+            delegate.didError(error: error)
+        } else {
+            delegate.didError(error: SmileIDError.unknown("onFinish with no result or error"))
+        }
+    }
+
+    func submitJob(selfieCaptureResultStore: SelfieCaptureResultStore) {
+        DispatchQueue.main.async { self.step = .processing(.inProgress) }
+        guard let idInfo = idInfo else {
+            print("idInfo is nil")
+            error = SmileIDError.unknown("idInfo is nil")
+            DispatchQueue.main.async { self.step = .processing(.error) }
+            return
+        }
+        Task {
+            do {
+                let livenessImages = selfieCaptureResultStore.livenessImages
+                let selfieImage = selfieCaptureResultStore.selfie
+                let infoJson = try LocalStorage.createInfoJson(
+                    selfie: selfieImage,
+                    livenessImages: livenessImages,
+                    idInfo: idInfo
+                )
+                let zipUrl = try LocalStorage.zipFiles(
+                    at: livenessImages + [selfieImage] + [infoJson]
+                )
+                let zip = try Data(contentsOf: zipUrl)
+                let authRequest = AuthenticationRequest(
+                    jobType: .biometricKyc,
+                    enrollment: false,
+                    jobId: jobId,
+                    userId: userId
+                )
+                let authResponse = try await SmileID.api.authenticate(request: authRequest).async()
+                let prepUploadRequest = PrepUploadRequest(
+                    partnerParams: authResponse.partnerParams,
+                    timestamp: authResponse.timestamp,
+                    signature: authResponse.signature
+                )
+                let prepUploadResponse = try await SmileID.api.prepUpload(
+                    request: prepUploadRequest
+                ).async()
+                let _ = try await SmileID.api.upload(
+                    zip: zip,
+                    to: prepUploadResponse.uploadUrl
+                ).async()
+                let jobStatusRequest = JobStatusRequest(
+                    userId: userId,
+                    jobId: jobId,
+                    includeImageLinks: false,
+                    includeHistory: false,
+                    timestamp: authResponse.timestamp,
+                    signature: authResponse.signature
+                )
+                jobStatusResponse = try await SmileID.api.getJobStatus(
+                    request: jobStatusRequest
+                ).async()
+                DispatchQueue.main.async { self.step = .processing(.success) }
+            } catch {
+                print("Error submitting job: \(error)")
+                self.error = error
+                DispatchQueue.main.async { self.step = .processing(.error) }
+            }
+        }
+    }
+}

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -126,7 +126,7 @@ internal class OrchestratedBiometricKycViewModel: ObservableObject, SelfieImageC
     func onConsentGranted(country: String, idType: String, requiredFields: [RequiredField]) {
         // If idInfo is already set, it was passed in, so we skip straight to selfie capture -- the
         // partner is required to pass in all required inputs
-        if let _ = idInfo {
+        if idInfo != nil {
             DispatchQueue.main.async { self.step = .selfie }
         } else {
             DispatchQueue.main.async {

--- a/Sources/SmileID/Classes/Consent/OrchestratedConsentScreen.swift
+++ b/Sources/SmileID/Classes/Consent/OrchestratedConsentScreen.swift
@@ -104,11 +104,16 @@ private struct ConsentScreen: View {
 
             Spacer()
             Divider()
-            Text("You can view \(partnerName)'s Privacy Policy here")
+            Text(
+                SmileIDResourcesHelper.localizedString(
+                    for: "Consent.ViewPrivacyPolicy",
+                    partnerName
+                )
+            )
                 .foregroundColor(SmileID.theme.accent)
                 .font(SmileID.theme.body)
                 .onTapGesture { UIApplication.shared.open(partnerPrivacyPolicy) }
-            Text("By choosing 'Allow' you grant \(partnerName) consent to process your personal data to offer you this service")
+            Text(SmileIDResourcesHelper.localizedString(for: "Consent.Disclaimer", partnerName))
                 .foregroundColor(SmileID.theme.onLight)
                 .font(SmileID.theme.body)
             VStack(spacing: 8) {

--- a/Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift
@@ -11,7 +11,7 @@ struct CaptureButton: View {
     }
 }
 
-struct CaptureButton_Previews: PreviewProvider {
+private struct CaptureButton_Previews: PreviewProvider {
     static var previews: some View {
         CaptureButton {}
     }

--- a/Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift
+++ b/Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift
@@ -37,13 +37,16 @@ public class SmileIDResourcesHelper {
         }
     }
 
-    /// Get localized strings
-    public static func localizedString(for key: String) -> String {
-        NSLocalizedString(
-            key,
-            tableName: SmileID.localizableStrings?.tablename,
-            bundle: SmileID.localizableStrings?.bundle ?? bundle,
-            comment: ""
+    /// Get localized, parametrized strings
+    public static func localizedString(for key: String, _ args: CVarArg...) -> String {
+        String(
+            format: NSLocalizedString(
+                key,
+                tableName: SmileID.localizableStrings?.tablename,
+                bundle: SmileID.localizableStrings?.bundle ?? bundle,
+                comment: ""
+            ),
+            arguments: args
         )
     }
 

--- a/Sources/SmileID/Classes/Navigation/NavigationBar.swift
+++ b/Sources/SmileID/Classes/Navigation/NavigationBar.swift
@@ -15,7 +15,7 @@ struct NavigationBar: View {
     }
 }
 
-struct NavigationBar_Previews: PreviewProvider {
+private struct NavigationBar_Previews: PreviewProvider {
     static var previews: some View {
         NavigationBar(backButtonHandler: {})
     }

--- a/Sources/SmileID/Classes/Networking/APIError.swift
+++ b/Sources/SmileID/Classes/Networking/APIError.swift
@@ -8,6 +8,7 @@ public enum SmileIDError: Error {
     case api(String, String)
     case httpError(Int, Data)
     case jobStatusTimeOut
+    case consentDenied
 }
 
 extension SmileIDError: LocalizedError {
@@ -27,6 +28,8 @@ extension SmileIDError: LocalizedError {
             return message
         case .jobStatusTimeOut:
             return "Job submitted successfully but polling job status timed out"
+        case .consentDenied:
+            return "Consent Denied"
         }
     }
 }

--- a/Sources/SmileID/Classes/Networking/Models/Authentication.swift
+++ b/Sources/SmileID/Classes/Networking/Models/Authentication.swift
@@ -81,7 +81,7 @@ public struct AuthenticationResponse: Decodable {
     public var signature: String
     public var timestamp: String
     public var partnerParams: PartnerParams
-    public var consentInfo: ConsentInfo? = nil
+    public var consentInfo: ConsentInfo?
 
     public init(
         success: Bool,

--- a/Sources/SmileID/Classes/Networking/Models/Authentication.swift
+++ b/Sources/SmileID/Classes/Networking/Models/Authentication.swift
@@ -1,11 +1,35 @@
 import Foundation
 
+/// The Auth Smile request. Auth Smile serves multiple purposes:
+/// - It is used to fetch the signature needed for subsequent API requests
+/// - It indicates the type of job that will being performed
+/// - It is used to fetch consent information for the partner
+///
+///  - Parameters:
+///    - jobType: The type of job that will be performed
+///    - enrollment: Whether or not this is an enrollment job
+///    - country: The country code of the country where the job is being performed. This value is
+///       required in order to get back consent information for the partner
+///    - idType: The type of ID that will be used for the job. This value is required in order to
+///      get back consent information for the partner
+///    - updateEnrolledImage: Whether or not the enrolled image should be updated with image
+///      submitted for this job
+///    - jobId: The job ID to associate with the job. Most often, this will correspond to a unique
+///      Job ID within your own system. If not provided, a random job ID will be generated
+///    - userId: The user ID to associate with the job. Most often, this will correspond to a unique
+///      User ID within your own system. If not provided, a random user ID will be generated
+///    - signature: Whether or not to fetch the signature for the job
+///    - production: Whether or not to use the production environment
+///    - partnerId: The partner ID
+///    - authToken: The auth token from smile_config.json
 public struct AuthenticationRequest: Codable {
     public var jobType: JobType?
     public var enrollment: Bool
     public var updateEnrolledImage: Bool?
     public var jobId: String?
     public var userId: String?
+    public var country: String?
+    public var idType: String?
     public var signature = true
     public var production = !SmileID.useSandbox
     public var partnerId = SmileID.config.partnerId
@@ -17,6 +41,8 @@ public struct AuthenticationRequest: Codable {
         case updateEnrolledImage = "update_enrolled_image"
         case jobId = "job_id"
         case userId = "user_id"
+        case country
+        case idType = "id_type"
         case signature
         case production
         case partnerId = "partner_id"
@@ -25,10 +51,12 @@ public struct AuthenticationRequest: Codable {
 
     public init(
         jobType: JobType?,
-        enrollment: Bool,
+        enrollment: Bool = false,
         updateEnrolledImage: Bool? = nil,
         jobId: String? = nil,
         userId: String? = nil,
+        country: String? = nil,
+        idType: String? = nil,
         signature: Bool = true,
         production: Bool = !SmileID.useSandbox,
         partnerId: String = SmileID.config.partnerId,
@@ -39,6 +67,8 @@ public struct AuthenticationRequest: Codable {
         self.updateEnrolledImage = updateEnrolledImage
         self.jobId = jobId
         self.userId = userId
+        self.country = country
+        self.idType = idType
         self.signature = signature
         self.production = production
         self.partnerId = partnerId
@@ -51,6 +81,7 @@ public struct AuthenticationResponse: Decodable {
     public var signature: String
     public var timestamp: String
     public var partnerParams: PartnerParams
+    public var consentInfo: ConsentInfo? = nil
 
     public init(
         success: Bool,
@@ -69,5 +100,16 @@ public struct AuthenticationResponse: Decodable {
         case signature
         case timestamp
         case partnerParams = "partner_params"
+        case consentInfo = "consent_info"
+    }
+}
+
+public struct ConsentInfo: Decodable {
+    public var canAccess: Bool
+    public var consentRequired: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case canAccess = "can_access"
+        case consentRequired = "consent_required"
     }
 }

--- a/Sources/SmileID/Classes/Networking/Models/Services.swift
+++ b/Sources/SmileID/Classes/Networking/Models/Services.swift
@@ -128,7 +128,29 @@ public enum RequiredField: String, Codable {
     case idType = "id_type"
     case userId = "user_id"
     case jobId = "job_id"
-    case unknown = "Unknown"
+
+    // To allow displaying inputs in some logical+consistent order
+    private static let sortedCases: [RequiredField] = [
+        .idNumber,
+        .firstName,
+        .lastName,
+        .dateOfBirth,
+        .day,
+        .month,
+        .year,
+        .bankCode,
+        .citizenship,
+        .country,
+        .idType,
+        .userId,
+        .jobId,
+    ]
+
+    static func sorter(this: RequiredField, that: RequiredField) -> Bool {
+        let thisIndex = sortedCases.firstIndex(of: this) ?? 0
+        let thatIndex = sortedCases.firstIndex(of: that) ?? 0
+        return thisIndex < thatIndex
+    }
 }
 
 // MARK: - CountryCodeToCountryInfo

--- a/Sources/SmileID/Classes/Networking/Models/Services.swift
+++ b/Sources/SmileID/Classes/Networking/Models/Services.swift
@@ -143,7 +143,7 @@ public enum RequiredField: String, Codable {
         .country,
         .idType,
         .userId,
-        .jobId,
+        .jobId
     ]
 
     static func sorter(this: RequiredField, that: RequiredField) -> Bool {

--- a/Sources/SmileID/Classes/Networking/Models/Services.swift
+++ b/Sources/SmileID/Classes/Networking/Models/Services.swift
@@ -72,10 +72,12 @@ public struct HostedWeb: Codable {
  * mutable. However, it should be populated before usage of this class/when the response gets decoded.
  * The same applies to availableIdTypes
  */
-public struct CountryInfo: Codable {
+public struct CountryInfo: Codable, Identifiable {
     public var countryCode = ""
     public let name: String
     public let availableIdTypes: [AvailableIdType]
+
+    public var id: String { countryCode }
 
     private enum CodingKeys: String, CodingKey {
         case name
@@ -97,12 +99,14 @@ public struct CountryInfo: Codable {
  * The  idTypeKey field is not populated/returned by the API response, hence it being marked as
  * mutable. However, it should be populated before usage of this class/when the response gets decoded
  */
-public struct AvailableIdType: Codable {
+public struct AvailableIdType: Codable, Identifiable, Equatable {
     public var idTypeKey = ""
     public let label: String
-    public let requiredFields: [RequiredField] = []
+    public let requiredFields: [RequiredField]?
     public let testData: String?
     public let idNumberRegex: String?
+
+    public var id: String { idTypeKey }
 
     private enum CodingKeys: String, CodingKey {
         case label

--- a/Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift
+++ b/Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift
@@ -80,10 +80,14 @@ public struct ProductsConfigRequest: Encodable {
         signature = try? calculateSignature(timestamp: timestamp)
     }
 
-    public init(partnerId: String, timestamp: String, signature: String) {
-        self.partnerId = partnerId
+    public init(
+        timestamp: String,
+        signature: String,
+        partnerId: String = SmileID.config.partnerId
+    ) {
         self.signature = signature
         self.timestamp = timestamp
+        self.partnerId = partnerId
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/SmileID/Classes/SelfieCapture/View/FaceOverlayView.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/FaceOverlayView.swift
@@ -20,7 +20,11 @@ struct FaceOverlayView: View {
                                 .frame(width: faceWidth, height: faceHeight)
                                 .background(GeometryReader { localGeometry in
                                     Color.clear.onReceive(
+                                        // The delay is needed for when the view could be going
+                                        // through a transition (i.e. resizing because the keyboard
+                                        // is in the process of getting dismissed)
                                         Just(localGeometry.frame(in: .global))
+                                            .delay(for: 0.5, scheduler: DispatchQueue.main)
                                     ) { globalFrame in
                                         let globalOriginX = globalFrame.origin.x
                                         let faceOriginX = model.faceLayoutGuideFrame.origin.x

--- a/Sources/SmileID/Classes/SelfieCapture/View/FaceShape.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/FaceShape.swift
@@ -56,7 +56,7 @@ struct FaceShape: Shape {
     }
 }
 
-struct FaceShape_Previews: PreviewProvider {
+private struct FaceShape_Previews: PreviewProvider {
     static var previews: some View {
         FaceShape()
     }

--- a/Sources/SmileID/Classes/SelfieCapture/View/InstructionsView.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/InstructionsView.swift
@@ -17,7 +17,7 @@ struct InstructionsView: View {
     }
 }
 
-struct InstructionsView_Previews: PreviewProvider {
+private struct InstructionsView_Previews: PreviewProvider {
     static var previews: some View {
         InstructionsView(
             model: SelfieCaptureViewModel(

--- a/Sources/SmileID/Classes/SelfieCapture/View/ProcessingView.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/ProcessingView.swift
@@ -33,7 +33,7 @@ struct ProcessingView: View {
     }
 }
 
-struct ProcessingView_Previews: PreviewProvider {
+private struct ProcessingView_Previews: PreviewProvider {
     static var previews: some View {
         ProcessingView(
             image: SmileIDResourcesHelper.FaceOutline,

--- a/Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift
@@ -78,7 +78,7 @@ public struct SmileButton: View {
     }
 }
 
-struct SmileButton_Previews: PreviewProvider {
+private struct SmileButton_Previews: PreviewProvider {
     static var previews: some View {
         SmileButton(
             title: "Instructions.Action",

--- a/Sources/SmileID/Classes/SelfieCapture/View/SuccessView.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/SuccessView.swift
@@ -36,7 +36,7 @@ struct SuccessView: View {
     }
 }
 
-struct SuccessView_Previews: PreviewProvider {
+private struct SuccessView_Previews: PreviewProvider {
     static var previews: some View {
         SuccessView(
             titleKey: "Confirmation.SelfieCaptureComplete",

--- a/Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureResultStore.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureResultStore.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 struct SelfieCaptureResultStore {
-    var allFiles: [URL]
     var selfie: URL
     var livenessImages: [URL]
 }

--- a/Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureViewModel.swift
@@ -405,11 +405,13 @@ final class SelfieCaptureViewModel: ObservableObject, JobSubmittable, Confirmati
         processingState = .inProgress
         var zip: Data
         do {
-            savedFiles = try LocalStorage.saveImageJpg(
-                livenessImages: livenessImages,
-                previewImage: selfieImage
+            savedFiles = try LocalStorage.saveSelfieImages(
+                selfieImage: selfieImage,
+                livenessImages: livenessImages
             )
-            let zipUrl = try LocalStorage.zipFiles(at: savedFiles!.allFiles)
+            let zipUrl = try LocalStorage.zipFiles(
+                at: savedFiles!.livenessImages + [savedFiles!.selfie]
+            )
             zip = try Data(contentsOf: zipUrl)
         } catch {
             processingState = .error(error)
@@ -487,7 +489,7 @@ final class SelfieCaptureViewModel: ObservableObject, JobSubmittable, Confirmati
             selfieImage = nil
         }
         if let savedFiles = savedFiles {
-            try? LocalStorage.delete(at: savedFiles.allFiles)
+            try? LocalStorage.delete(at: savedFiles.livenessImages + [savedFiles.selfie])
         }
     }
 

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -307,6 +307,18 @@ public class SmileID {
         showInstructions: Bool = true,
         delegate: BiometricKycResultDelegate
     ) -> some View {
-        Text("Under Construction")
+        OrchestratedBiometricKycScreen(
+            idInfo: idInfo,
+            userId: userId,
+            jobId: jobId,
+            partnerIcon: partnerIcon,
+            partnerName: partnerName,
+            productName: productName,
+            partnerPrivacyPolicy: partnerPrivacyPolicy,
+            showInstructions: showInstructions,
+            showAttribution: showAttribution,
+            allowAgentMode: allowAgentMode,
+            delegate: delegate
+        )
     }
 }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -277,11 +277,13 @@ public class SmileID {
     /// actually belongs to the user. This is achieved by comparing the user's SmartSelfie™ to the
     /// user's photo in an ID authority database
     /// - Parameters:
-    ///  - idInfo: The ID information to look up in the ID Authority
     ///  - partnerIcon: Your own icon to display on the Biometric KYC screen (i.e. company logo)
     ///  - partnerName: Your own name to display on the Biometric KYC screen (i.e. company name)
     ///  - productName: The type of information you are trying to access (i.e. ID type)
     ///  - partnerPrivacyPolicy: A link to your own privacy policy to display
+    ///  - idInfo: The ID information to look up in the ID Authority. If nil (default), an ID type
+    ///  selector and input fields will be displayed. If provided, it is assumed that ALL required
+    ///  information has already been provided
     ///  - userId: The user ID to associate with the Biometric KYC. Most often, this will correspond
     ///  to a unique User ID within your own system. If not provided, a random user ID is generated
     ///  - jobId: The job ID to associate with the Biometric KYC. Most often, this will correspond
@@ -293,11 +295,11 @@ public class SmileID {
     ///  - showInstructions: Whether to deactivate capture screen's instructions for SmartSelfie.
     ///  - delegate: Callback to be invoked when the Biometric KYC is complete.
     public class func biometricKycScreen(
-        idInfo: IdInfo,
         partnerIcon: UIImage,
         partnerName: String,
         productName: String,
         partnerPrivacyPolicy: URL,
+        idInfo: IdInfo? = nil,
         userId: String = generateUserId(),
         jobId: String = generateJobId(),
         allowAgentMode: Bool = false,

--- a/Sources/SmileID/Classes/Views/RadioGroupSelector.swift
+++ b/Sources/SmileID/Classes/Views/RadioGroupSelector.swift
@@ -74,7 +74,7 @@ public struct RadioGroupSelector<T>: View where T: Identifiable & Equatable {
 }
 
 @available(iOS 14.0, *)
-struct RadioGroupSelector_Previews: PreviewProvider {
+private struct RadioGroupSelector_Previews: PreviewProvider {
     static var previews: some View {
         let first = IdType(code: "id1", example: [], hasBack: true, name: "ID 1")
         RadioGroupSelector(

--- a/Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift
+++ b/Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift
@@ -75,7 +75,7 @@ public struct SearchableDropdownSelector<T: Identifiable>: View {
 }
 
 @available(iOS 14.0, *)
-struct SearchableDropdownSelectorUnselected_Previews: PreviewProvider {
+private struct SearchableDropdownSelectorUnselected_Previews: PreviewProvider {
     static var previews: some View {
         SearchableDropdownSelector(
             items: [
@@ -96,7 +96,7 @@ struct SearchableDropdownSelectorUnselected_Previews: PreviewProvider {
 }
 
 @available(iOS 14.0, *)
-struct SearchableDropdownSelectorSelected_Previews: PreviewProvider {
+private struct SearchableDropdownSelectorSelected_Previews: PreviewProvider {
     static var previews: some View {
         let first = ValidDocument(
             country: Country(code: "us", continent: "NA", name: "United States"),

--- a/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
@@ -59,6 +59,8 @@
 "Document.Directive.Default" = "Please fill the frame with your ID. Ensure all corners are visible and there is no glare";
 "Document.Directive.Capturing" = "Capturing…";
 
+"Consent.ViewPrivacyPolicy" = "You can view %@'s privacy policy here";
+"Consent.Disclaimer" = "By choosing 'Allow' you grant %@ consent to process your personal data to offer you this service";
 "Consent.Denied" = "Consent Denied";
 "Consent.DeniedTitle" = "We cannot verify without your consent";
 "Consent.DeniedDescription" = "Do you wish to go back and correct that?";

--- a/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
@@ -72,3 +72,13 @@
 "Consent.ContactInfoSubtitle" = "Partner can process your phone numbers and address";
 "Consent.DocumentInfoTitle" = "Process your document information";
 "Consent.DocumentInfoSubtitle" = "Partner can process your photo, ID expiration date, country of issuance and document number";
+
+"IdInfo.IdNumber" = "ID Number";
+"IdInfo.FirstName" = "First Name";
+"IdInfo.LastName" = "Last Name";
+"IdInfo.DOB" = "Date of Birth";
+"IdInfo.Day" = "Day";
+"IdInfo.Month" = "Month";
+"IdInfo.Year" = "Year";
+"IdInfo.BankCode" = "Bank Code";
+"IdInfo.Citizenship" = "Citizenship";

--- a/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
@@ -82,3 +82,14 @@
 "IdInfo.Year" = "Year";
 "IdInfo.BankCode" = "Bank Code";
 "IdInfo.Citizenship" = "Citizenship";
+
+"BiometricKYC.Loading.IdTypes" = "Loading ID Types…";
+"BiometricKYC.SelectIdType" = "Select ID Type";
+"BiometricKYC.Loading.Consent" = "Loading…";
+"BiometricKYC.EnterIdInfoTitle" = "Enter ID Information";
+"BiometricKYC.Processing.Title" = "Processing your Selfie and ID";
+"BiometricKYC.Processing.Subtitle" = "Just a few more seconds";
+"BiometricKYC.Success.Title" = "Submission Complete";
+"BiometricKYC.Success.Subtitle" = "You may now proceed";
+"BiometricKYC.Error.Title" = "Your submission failed to process";
+"BiometricKYC.Error.Subtitle" = "This could be because of image quality or internet connectivity";


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/8953

## Summary

Adds Biometric KYC. The meat of this PR is mainly in 2 files: `OrchestratedBiometricKycViewModel.swift` and `OrchestratedBiometricKycScreen.swift`. 

This also:
- Introduces a new extension to the `AnyPublisher` type that plays nicely with Swift's concurrency framework. This allows us to use a nice `async`/`await` paradigm over the rather ugly `Combine` API. We can leverage this moving forward throughout the SDK and app. Eventually, we may want to transition the `SmileIDService` to be natively defined as async functions.
- Adds parametrized, localized strings