### PR TITLE
Require ID Info entry when consent required

### DIFF
--- a/Sources/SmileID/Classes/BiometricKYC/IdInfoInputScreen.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/IdInfoInputScreen.swift
@@ -7,12 +7,14 @@ import SwiftUI
 /// - Parameters:
 ///  - selectedCountry: The country code of the selected country
 ///  - selectedIdType: The ID type code of the selected ID type
-///  - header: The header to display at the top of the screen
+///  - title: The header to display at the top of the screen
+///  - subtitle: The subheader to display at the top of the screen
 ///  - requiredFields: The fields that the user must enter
 ///  - onResult: The callback to invoke when the user taps the Continue button. The result will be
 ///  delivered as an `IdInfo` object.
 struct IdInfoInputScreen: View {
-    let header: String
+    let title: String
+    let subtitle: String?
     let onResult: (IdInfo) -> Void
     let dateFormatter = DateFormatter()
     @ObservedObject var viewModel: IdInfoInputViewModel
@@ -20,11 +22,13 @@ struct IdInfoInputScreen: View {
     init(
         selectedCountry: String,
         selectedIdType: String,
-        header: String,
+        title: String,
+        subtitle: String? = nil,
         requiredFields: [RequiredField],
         onResult: @escaping (IdInfo) -> Void
     ) {
-        self.header = header
+        self.title = title
+        self.subtitle = subtitle
         self.onResult = onResult
         dateFormatter.dateFormat = "yyyy-MM-dd"
         viewModel = IdInfoInputViewModel(
@@ -38,11 +42,17 @@ struct IdInfoInputScreen: View {
         VStack(alignment: .center) {
             Form {
                 Section(
-                    header: Text(header)
+                    header: Text(title)
                         .font(SmileID.theme.header2)
                         .foregroundColor(SmileID.theme.onLight)
                         .padding(.vertical, 8)
                 ) {
+                    if let subtitle = subtitle {
+                        Text(subtitle)
+                            .font(SmileID.theme.body)
+                            .foregroundColor(SmileID.theme.onLight)
+                            .padding(.vertical, 8)
+                    }
                     let sortedKeys = viewModel.inputs.keys.sorted(by: RequiredField.sorter)
                     ForEach(sortedKeys, id: \.self) { key in
                         let localizedLabel = SmileIDResourcesHelper.localizedString(
@@ -117,7 +127,7 @@ private struct IdInfoInputScreen_Previews: PreviewProvider {
         IdInfoInputScreen(
             selectedCountry: "US",
             selectedIdType: "Driver's License",
-            header: "Enter ID Info",
+            title: "Enter ID Info",
             requiredFields: [.idNumber, .firstName, .lastName, .dateOfBirth, .bankCode],
             onResult: { _ in }
         )

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
@@ -88,13 +88,16 @@ struct OrchestratedBiometricKycScreen: View {
                 },
                 onConsentDenied: { delegate.didError(error: SmileIDError.consentDenied) }
             )
-        case .idInput(let country, let idType, let requiredFields):
+        case .idInput(let country, let idType, let requiredFields, let showReEntryBlurb):
             IdInfoInputScreen(
                 selectedCountry: country,
                 selectedIdType: idType,
-                header: SmileIDResourcesHelper.localizedString(
+                title: SmileIDResourcesHelper.localizedString(
                     for: "BiometricKYC.EnterIdInfoTitle"
                 ),
+                subtitle: showReEntryBlurb ? SmileIDResourcesHelper.localizedString(
+                    for: "BiometricKYC.EnterIdInfo.ReEntrySubtitle"
+                ) : nil,
                 requiredFields: requiredFields,
                 onResult: viewModel.onIdFieldsEntered
             ).frame(maxWidth: .infinity)

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -285,7 +285,8 @@ public class SmileID {
     ///  - partnerPrivacyPolicy: A link to your own privacy policy to display
     ///  - idInfo: The ID information to look up in the ID Authority. If nil (default), an ID type
     ///  selector and input fields will be displayed. If provided, it is assumed that ALL required
-    ///  information has already been provided
+    ///  information has already been provided. If provided, but consent is required, we will ask
+    ///  the user to input their ID information again. It is best to omit this field.
     ///  - userId: The user ID to associate with the Biometric KYC. Most often, this will correspond
     ///  to a unique User ID within your own system. If not provided, a random user ID is generated
     ///  - jobId: The job ID to associate with the Biometric KYC. Most often, this will correspond

--- a/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
@@ -85,10 +85,10 @@
 "IdInfo.BankCode" = "Bank Code";
 "IdInfo.Citizenship" = "Citizenship";
 
-"BiometricKYC.Loading.IdTypes" = "Loading ID Types…";
+"BiometricKYC.Loading" = "Loading…";
 "BiometricKYC.SelectIdType" = "Select ID Type";
-"BiometricKYC.Loading.Consent" = "Loading…";
 "BiometricKYC.EnterIdInfoTitle" = "Enter ID Information";
+"BiometricKYC.EnterIdInfo.ReEntrySubtitle" = "Regulators require us to request your ID information again";
 "BiometricKYC.Processing.Title" = "Processing your Selfie and ID";
 "BiometricKYC.Processing.Subtitle" = "Just a few more seconds";
 "BiometricKYC.Success.Title" = "Submission Complete";


### PR DESCRIPTION
## Summary

If an `IdInfo` is passed in to Biometric KYC, but consent is required, we ignore the `IdInfo` passed as input and ask for the ID information again ouselves, per legal requirements