### PR TITLE
fix: remove AnyObject restriction so we can use delegates with structs

### DIFF
--- a/Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift
@@ -1,7 +1,7 @@
 /// The result of a Document Verification
 
 import Foundation
-public protocol DocumentVerificationResultDelegate: AnyObject {
+public protocol DocumentVerificationResultDelegate {
     /// Delegate method called after a successful Document Verification capture and submission.
     /// It indicates that the capture and network requests were successful. The job may or may not
     /// be complete. Use `jobStatusResponse.jobComplete` to check if a job is complete and

--- a/Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift
@@ -1,7 +1,7 @@
 /// The result of an Enhanced Document Verification
 
 import Foundation
-public protocol EnhancedDocumentVerificationResultDelegate: AnyObject {
+public protocol EnhancedDocumentVerificationResultDelegate {
     /// Delegate method called after a successful Enhanced Document Verification capture and
     /// submission. It indicates that the capture and network requests were successful. The job
     /// may or may not be complete. Use `jobStatusResponse.jobComplete` to check if a job is


### PR DESCRIPTION

## Summary

remove AnyObject restriction so we can use delegates with structs

## Known Issues

n/a

## Test Instructions

Everything should work as normal for the changed products the only difference is we can now use the delegates with structs not just classes
