### PR TITLE
Fix white document overlay cutout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 10.0.2 (unrleased)
+## 10.0.2 (unreleased)
 
 ### Added
 
 ### Changed
 
 ### Fixed
+- Fixed a bug on iOS 14 devices where the document cutout showed a white box instead
 
 ### Removed
 

--- a/Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift
@@ -1,19 +1,25 @@
 import SwiftUI
 
 struct DocumentShapedBoundingBox: View {
-    let aspectRatio: Double
-    let borderColor: Color
-    let cornerRadius = RoundedRectangle(cornerRadius: 16)
+    private let aspectRatio: Double
+    private let borderColor: Color
+    private let cutoutShape: ScaledShape<AspectRatioRoundedRectangle>
+
+    init(
+        aspectRatio: Double,
+        borderColor: Color
+    ) {
+        self.aspectRatio = aspectRatio
+        self.borderColor = borderColor
+        cutoutShape = AspectRatioRoundedRectangle(aspectRatio: aspectRatio, cornerRadius: 16)
+            .scale(0.85)
+    }
 
     var body: some View {
         ZStack {
-            Rectangle().foregroundColor(Color.black.opacity(0.7))
-            cornerRadius
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .aspectRatio(aspectRatio, contentMode: .fit)
-                .blendMode(.destinationOut)
-                .overlay(cornerRadius.stroke(borderColor, lineWidth: 4))
-                .padding(32)
+            Color.black.opacity(0.7)
+                .cutout(cutoutShape)
+                .overlay(cutoutShape.stroke(borderColor, lineWidth: 4))
         }
     }
 }

--- a/Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift
@@ -18,6 +18,8 @@ struct DocumentShapedBoundingBox: View {
     var body: some View {
         ZStack {
             Color.black.opacity(0.7)
+                // We use cutout here instead of .blendMode(.destinationOut) because that causes
+                // issues on iOS 14 devices
                 .cutout(cutoutShape)
                 .overlay(cutoutShape.stroke(borderColor, lineWidth: 4))
         }

--- a/Sources/SmileID/Classes/Util.swift
+++ b/Sources/SmileID/Classes/Util.swift
@@ -14,6 +14,8 @@ private func generateId(_ prefix: String) -> String {
 }
 
 public extension View {
+    /// Cuts out the given shape from the view. This is used instead of a ZStack with a shape and a
+    /// blendMode of .destinationOut because that causes issues on iOS 14 devices
     public func cutout<S: Shape>(_ shape: S) -> some View {
         self.clipShape(
             StackedShape(bottom: Rectangle(), top: shape),

--- a/Sources/SmileID/Classes/Util.swift
+++ b/Sources/SmileID/Classes/Util.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 public func generateJobId() -> String {
     generateId("job-")
@@ -10,4 +11,25 @@ public func generateUserId() -> String {
 
 private func generateId(_ prefix: String) -> String {
     prefix + UUID().uuidString
+}
+
+public extension View {
+    public func cutout<S: Shape>(_ shape: S) -> some View {
+        self.clipShape(
+            StackedShape(bottom: Rectangle(), top: shape),
+            style: FillStyle(eoFill: true)
+        )
+    }
+}
+
+private struct StackedShape<Bottom: Shape, Top: Shape>: Shape {
+    var bottom: Bottom
+    var top: Top
+
+    func path(in rect: CGRect) -> Path {
+        Path { path in
+            path.addPath(bottom.path(in: rect))
+            path.addPath(top.path(in: rect))
+        }
+    }
 }

--- a/Sources/SmileID/Classes/Views/AspectRatioRoundedRectangle.swift
+++ b/Sources/SmileID/Classes/Views/AspectRatioRoundedRectangle.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SwiftUI
+
+public struct AspectRatioRoundedRectangle: Shape {
+    var aspectRatio: CGFloat
+    var cornerRadius: CGFloat
+
+    public func path(in rect: CGRect) -> Path {
+        // Calculate the target size maintaining the aspect ratio
+        let targetSize: CGSize
+        let rectAspectRatio = rect.width / rect.height
+
+        if rectAspectRatio > aspectRatio {
+            // Rect is wider than desired, adjust width
+            let width = rect.height * aspectRatio
+            let xOffset = (rect.width - width) / 2
+            targetSize = CGSize(width: width, height: rect.height)
+            return RoundedRectangle(cornerRadius: cornerRadius)
+                .path(in: CGRect(origin: CGPoint(x: xOffset, y: 0), size: targetSize))
+        } else {
+            // Rect is taller than desired, adjust height
+            let height = rect.width / aspectRatio
+            let yOffset = (rect.height - height) / 2
+            targetSize = CGSize(width: rect.width, height: height)
+            return RoundedRectangle(cornerRadius: cornerRadius)
+                .path(in: CGRect(origin: CGPoint(x: 0, y: yOffset), size: targetSize))
+        }
+    }
+}


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11225

## Summary

This fixes a bug where the document cutout would display a white box on older iOS versions. Previously, we were using the `.destinationOut` blend mode. This change uses a different approach, leveraging `clipPath`, the `evenOdd` fill, and some stacked shapes. Inspiration is directly taken from here: http://josephvb.com/posts/cutout-shape/

## Known Issues

This addresses only the document overlay cutout, not the face shape cutout yet.

## Test Instructions

Visit the smart selfie capture screen and take a screenshot. Notice how the face shape is simply all black. Visit the document verification capture screen and take a screenshot. Notice that we can actually see the actual screen contents.

~I don't have an iOS 14 device to test on, so at the moment, it is difficult to say whether this actually addresses the issue. However, the pre-existing weird screenshot behavior seems like a red herring/proxy for the iOS 14 issue.~

Tested on an iOS 14 simulator by replacing the CameraView with `Color.red`, and ensuring that the red shows through

## Screenshot

![IMG_0063](https://github.com/smileidentity/ios/assets/6133201/38047f3e-8b90-4c74-a904-13d78d70954b)
![IMG_0062](https://github.com/smileidentity/ios/assets/6133201/870fd516-4119-4b57-9627-6a46db4c272a)

