### PR TITLE
Make AuthenticationResponse and ProductsConfigResponse Encodable

### DIFF
--- a/Sources/SmileID/Classes/Networking/Models/Authentication.swift
+++ b/Sources/SmileID/Classes/Networking/Models/Authentication.swift
@@ -76,7 +76,7 @@ public struct AuthenticationRequest: Codable {
     }
 }
 
-public struct AuthenticationResponse: Decodable {
+public struct AuthenticationResponse: Codable {
     public var success: Bool
     public var signature: String
     public var timestamp: String
@@ -104,7 +104,7 @@ public struct AuthenticationResponse: Decodable {
     }
 }
 
-public struct ConsentInfo: Decodable {
+public struct ConsentInfo: Codable {
     public var canAccess: Bool
     public var consentRequired: Bool
 

--- a/Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift
+++ b/Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift
@@ -99,7 +99,7 @@ public struct ProductsConfigRequest: Encodable {
 
 /// Country Code to ID Type (e.g. {"ZA": ["NATIONAL_ID_NO_PHOTO"]}
 public typealias IdTypes = [String: [String]]
-public struct ProductsConfigResponse: Decodable {
+public struct ProductsConfigResponse: Codable {
     public let consentRequired: IdTypes
     public let idSelection: IdSelection
 
@@ -109,7 +109,7 @@ public struct ProductsConfigResponse: Decodable {
     }
 }
 
-public struct IdSelection: Decodable {
+public struct IdSelection: Codable {
     public let basicKyc: IdTypes
     public let biometricKyc: IdTypes
     public let enhancedKyc: IdTypes


### PR DESCRIPTION
Makes AuthenticationResponse encodable for use with React Native