### PR TITLE
fix: correct impl for docv captureBothSides flag

### DIFF
--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -61,11 +61,11 @@ internal class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: Obse
         documentFrontFile = data
         if captureBothSides {
             DispatchQueue.main.async {
-                self.step = .selfieCapture
+                self.step = .backDocumentCapture
             }
         } else {
             DispatchQueue.main.async {
-                self.step = .backDocumentCapture
+                self.step = .selfieCapture
             }
         }
     }


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11352/ios-document-verification-capturebothsides-not-working-as-expected

## Summary

IOS capture both sides flag was invered so this fixes that

## Known Issues

n/a

## Test Instructions

On docv set captureBothSides to true or false this should work as expected instead of the inversion
