### PR TITLE
Draw camera cover under nav bar

### DIFF
--- a/Sources/SmileID/Classes/SelfieCapture/View/FaceShapedProgressIndicator.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/FaceShapedProgressIndicator.swift
@@ -20,5 +20,6 @@ struct FaceShapedProgressIndicator: View {
                     )
                     .animation(.easeInOut, value: progress)
             )
+            .edgesIgnoringSafeArea(.all)
     }
 }


### PR DESCRIPTION
Draws the white overlay on the selfie screen underneath the navigation bar