### PR TITLE
Upgrade runner to macOS 14

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -12,8 +12,8 @@ concurrency:
 
 jobs:
   build:
-    # TODO: Change back to macos-latest once it points to macOS 13
-    runs-on: macos-13
+    # TODO: Change back to macos-latest once it points to macOS 14 (Q2 '24)
+    runs-on: macos-14
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/carthage-release.yml
+++ b/.github/workflows/carthage-release.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: macos-latest
+    # TODO: Change back to macos-latest once it points to macOS 14 (Q2 '24)
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/sdk-primary.yml
+++ b/.github/workflows/sdk-primary.yml
@@ -31,8 +31,8 @@ jobs:
 
   build:
     name: "Build App and Run Unit Tests"
-    # TODO: Change back to macos-latest once it points to macOS 13
-    runs-on: macos-13
+    # TODO: Change back to macos-latest once it points to macOS 14 (Q2 '24)
+    runs-on: macos-14
     timeout-minutes: 15
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Upgrades the macOS runners to macOS 14. This comes with the additional benefit of running on M1 CPU cores now (previously this was only available on `-large` runners).

Additional details [here](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)