### PR TITLE
Disable Skip Button on Back ID Capture Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 
 ### Removed
+- Removed the Skip Button from Back of ID Capture
 
 ## 10.0.7
 

--- a/Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift
@@ -169,7 +169,7 @@ private struct IOrchestratedDocumentVerificationScreen<T, U: JobResult>: View {
                 showInstructions: showInstructions,
                 showAttribution: showAttribution,
                 allowGallerySelection: allowGalleryUpload,
-                showSkipButton: captureBothSides,
+                showSkipButton: false,
                 instructionsTitleText: SmileIDResourcesHelper.localizedString(
                     for: "Instructions.Document.Back.Header"
                 ),


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11625

## Summary

When capturing the back of ID, don't show the skip button
