### PR TITLE
Setup reference docs

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -54,3 +54,20 @@ jobs:
           labels: "release-notes"
           team-reviewers: "smileidentity/mobile"
 
+  generate-docc-reference-docs:
+    # TODO: Change back to macos-latest once it points to macOS 14 (Q2 '24)
+    runs-on: macos-14
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup environment
+        run: bundle install
+      - name: Select Xcode Version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+         xcode-version: 15.2
+      - name: Generate Archive
+        run:  xcodebuild docbuild -workspace Example/SmileID.xcworkspace -scheme SmileID -destination 'generic/platform=iOS' DOCC_OUTPUT_DIR=.
+      - name: Generate Docs Site
+        run: $(xcrun --find docc) process-archive transform-for-static-hosting Example/Pods/SmileID.doccarchive --output-path docs --hosting-base-path ios

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -58,16 +58,30 @@ jobs:
     # TODO: Change back to macos-latest once it points to macOS 14 (Q2 '24)
     runs-on: macos-14
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
-      - name: Checkout
+      - name: Checkout main branch
         uses: actions/checkout@v4
+        with:
+          path: ios
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          path: docs
+          ref: gh-pages
       - name: Setup environment
-        run: bundle install
+        run: cd ios && bundle install
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@v1
         with:
          xcode-version: 15.2
       - name: Generate Archive
-        run:  xcodebuild docbuild -workspace Example/SmileID.xcworkspace -scheme SmileID -destination 'generic/platform=iOS' DOCC_OUTPUT_DIR=.
+        run:  xcodebuild docbuild -workspace ios/Example/SmileID.xcworkspace -scheme SmileID -destination 'generic/platform=iOS' DOCC_OUTPUT_DIR=.
       - name: Generate Docs Site
-        run: $(xcrun --find docc) process-archive transform-for-static-hosting Example/Pods/SmileID.doccarchive --output-path docs --hosting-base-path ios
+        run: $(xcrun --find docc) process-archive transform-for-static-hosting ios/Example/Pods/SmileID.doccarchive --output-path docs --hosting-base-path ios
+      - name: Push gh-pages branch
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          repository: docs
+          branch: gh-pages

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -17,6 +17,7 @@ post_install do |installer|
     project.targets.each do |target|
         target.build_configurations.each do |config|
             config.build_settings["DEVELOPMENT_TEAM"] = "99P7YGX9Q6"
+            config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
          end
     end
   end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - netfox (1.21.0)
-  - Sentry (8.20.0):
-    - Sentry/Core (= 8.20.0)
-    - SentryPrivate (= 8.20.0)
-  - Sentry/Core (8.20.0):
-    - SentryPrivate (= 8.20.0)
-  - SentryPrivate (8.20.0)
+  - Sentry (8.21.0):
+    - Sentry/Core (= 8.21.0)
+    - SentryPrivate (= 8.21.0)
+  - Sentry/Core (8.21.0):
+    - SentryPrivate (= 8.21.0)
+  - SentryPrivate (8.21.0)
   - SmileID (10.0.10):
     - Zip (~> 2.1.0)
   - SwiftLint (0.54.0)
@@ -31,12 +31,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
-  Sentry: a8d7b373b9f9868442b02a0c425192f693103cbf
-  SentryPrivate: 006b24af16828441f70e2ab6adf241bd0a8ad130
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   SmileID: ffaa1eab202cb9c402ade1cc66ceaf5a2c99c686
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
-PODFILE CHECKSUM: 81f36d854eaf9451aa489ca090d5c32269373e5d
+PODFILE CHECKSUM: 8f7be2cf75babf479684f1e21d344f4c640486be
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/11924

## Summary

Generates and publishes reference docs any time a release is created. The docs source live on the newly created `gh-pages` branch. It is accessible at https://smileidentity.github.io/ios/documentation/smileid/

## Test Instructions

Visit https://smileidentity.github.io/ios/documentation/smileid/. The docs generation workflow will be exercised the next time a release is created
