### PR TITLE
Add PrivacyInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-
 # Release Notes
+
+## Unreleased
+* Add PrivacyInfo Manifest
+
 ## 10.0.11
 
 #### Fixed

--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -24,13 +24,14 @@
 		1ED53F722A2F28590020BEFB /* SmileEnvironmentToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F682A2F28590020BEFB /* SmileEnvironmentToggleButton.swift */; };
 		1ED53F732A2F28590020BEFB /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED53F692A2F28590020BEFB /* HomeView.swift */; };
 		1EFAB3172A375265008E3C13 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
+		5829A8C02BC7429A001C1E7E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 5829A8BF2BC7429A001C1E7E /* PrivacyInfo.xcprivacy */; };
 		585BE4882AC7748E0091DDD8 /* RestartableTimerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585BE4872AC7748E0091DDD8 /* RestartableTimerTest.swift */; };
 		58C5F1D82B05925800A6080C /* BiometricKycWithIdInputScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C5F1D72B05925800A6080C /* BiometricKycWithIdInputScreen.swift */; };
 		58C7118C2A69DE920062BBFB /* EnhancedKycTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7118B2A69DE920062BBFB /* EnhancedKycTest.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		620F1E982B69194900185CD2 /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620F1E972B69194900185CD2 /* AlertView.swift */; };
-		620F1E9A2B691ABB00185CD2 /* BuildFile in Resources */ = {isa = PBXBuildFile; };
+		620F1E9A2B691ABB00185CD2 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		624777D02B0CDC9F00952842 /* EnhancedKycWithIdInputScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624777CF2B0CDC9F00952842 /* EnhancedKycWithIdInputScreen.swift */; };
 		62F6766F2B0D173600417419 /* EnhancedKycWithIdInputScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F6766E2B0D173600417419 /* EnhancedKycWithIdInputScreenViewModel.swift */; };
 		62F676712B0E00E800417419 /* EnhancedKycResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F676702B0E00E800417419 /* EnhancedKycResultDelegate.swift */; };
@@ -86,6 +87,7 @@
 		1ED53F692A2F28590020BEFB /* HomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		262BF9A8643DF9220FD233E3 /* Pods-SmileID_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SmileID_Example.release.xcconfig"; path = "Target Support Files/Pods-SmileID_Example/Pods-SmileID_Example.release.xcconfig"; sourceTree = "<group>"; };
 		287986BB9E93D632523CC13A /* Pods_SmileID_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SmileID_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5829A8BF2BC7429A001C1E7E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		585BE4872AC7748E0091DDD8 /* RestartableTimerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestartableTimerTest.swift; sourceTree = "<group>"; };
 		58C5F1D72B05925800A6080C /* BiometricKycWithIdInputScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricKycWithIdInputScreen.swift; sourceTree = "<group>"; };
 		58C7118B2A69DE920062BBFB /* EnhancedKycTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedKycTest.swift; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				6AC982F34F80CAE1AA5569AB /* WelcomeScreen.swift */,
 				6AC98DDBE27D169AF8DB4B98 /* CodeScanner */,
 				620F1E972B69194900185CD2 /* AlertView.swift */,
+				5829A8BF2BC7429A001C1E7E /* PrivacyInfo.xcprivacy */,
 			);
 			name = Example;
 			path = SmileID;
@@ -430,8 +433,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				1EFAB3172A375265008E3C13 /* Images.xcassets in Resources */,
-				620F1E9A2B691ABB00185CD2 /* BuildFile in Resources */,
+				620F1E9A2B691ABB00185CD2 /* (null) in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
+				5829A8C02BC7429A001C1E7E /* PrivacyInfo.xcprivacy in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/SmileID/PrivacyInfo.xcprivacy
+++ b/Example/SmileID/PrivacyInfo.xcprivacy
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     targets: [
         .target(
             name: "SmileID",
-            dependencies: ["Zip"],
+            dependencies: ["Zip", "lottie-spm"],
             path: "Sources/SmileID",
             resources: [.process("Resources")]
         ),

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.5'
   s.source_files = 'Sources/SmileID/Classes/**/*'
   s.resource_bundles = {
-    'SmileID_SmileID' => ['Sources/SmileID/Resources/**/*.{storyboard,storyboardc,xib,nib,xcassets,json,png,ttf,lproj}']
+    'SmileID_SmileID' => ['Sources/SmileID/Resources/**/*.{storyboard,storyboardc,xib,nib,xcassets,json,png,ttf,lproj,xcprivacy}']
   }
 end

--- a/SmileID.xcodeproj/project.pbxproj
+++ b/SmileID.xcodeproj/project.pbxproj
@@ -21,30 +21,28 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		015D86BBD180C7E8CC4F6CF2 /* DependencyAutoResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1367CC19F810B6CF7FB9D90 /* DependencyAutoResolver.swift */; };
 		048700B3A53E9D7F937AECD5 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE231057AA9714E2BD0C334A /* HTTPHeader.swift */; };
 		04FD39A81A9EC2B530695DFE /* SmartSelfieResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42F9CCECF77002036B86892 /* SmartSelfieResultDelegate.swift */; };
-		0594E4C7825C7B2347CBD1CD /* InfiniteProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635FE1B0E58159F477C188F9 /* InfiniteProgressBar.swift */; };
+		065CFC14C26E343D5AA4CD99 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7B9CB0FB27584F272064C7 /* APIError.swift */; };
 		0661654F21C35C16EFFFC48B /* FaceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132784950CC72ECA15B2554 /* FaceDetector.swift */; };
 		06704F74006CE588CF31C8CC /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4A6D69CC6F29B15095D09E /* Authentication.swift */; };
 		07CFDB250829DB24C623830A /* BVN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F0465FD3DA2CE6859EB059 /* BVN.swift */; };
+		07EEE981C6890F7A323F972F /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4119D363BCC420540C7750 /* Authentication.swift */; };
+		0A7BB6963FC2C07FBE2EED80 /* AspectRatioRoundedRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FF7E77C168337E221826F5 /* AspectRatioRoundedRectangle.swift */; };
+		0AC47C2ED1A6FC15E522A820 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F79721370C7B2353C8447ED /* CameraView.swift */; };
 		0B1E4A1BBA4E80C3CA4E66A8 /* JobStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921AE1DE1E9B98FDA31B74D2 /* JobStatus.swift */; };
+		0B590B1435EA930EE91173BD /* FaceDetectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06105CBE10AACF8136C7E31A /* FaceDetectionState.swift */; };
 		0B5FA6BE34260EE02DEFC7D0 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7B3CE7A0775B9FF6895565 /* ActivityIndicator.swift */; };
 		0BD3D4E53EA0D9B4642390B3 /* RadioGroupSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E93D1CD541B59039CC94578 /* RadioGroupSelector.swift */; };
 		0BD45AE514CFDE9EE69576A9 /* SelfieCaptureInstructionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F81A3B4B85FBEB6D92AD3A /* SelfieCaptureInstructionsScreen.swift */; };
 		0C17BFBD22BE8846EAA53E15 /* SmileID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A9875AF7FDE92B02A0DEB4 /* SmileID.swift */; };
-		0FCA4686C785CCF42F890069 /* SmileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B539C714BD126023578C76E /* SmileButton.swift */; };
 		118F4978ED8F2D6A89319450 /* NavigationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAE20D478DD83BF10E71B4A /* NavigationHelper.swift */; };
-		123B3DC333A8D52F6E27704E /* DocumentCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F562D9290BB958286154218 /* DocumentCaptureScreen.swift */; };
-		15C9C51CD05FB5B905F0A512 /* FaceShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 347E8C980B8C3D079B114F21 /* FaceShape.swift */; };
+		121DFEFF548D011CBA7A84D3 /* RestServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7A459BDE41CD5A574427BF /* RestServiceClient.swift */; };
 		15DF2BF9DEFFD6BF8BF4ACBB /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299ECBEAB067527186176C6A /* Injected.swift */; };
-		16ED9816E06FDB4B360E4A39 /* FontType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21FEB49B2606931367CBCC8 /* FontType.swift */; };
-		17110A590176503EFB7C49FF /* SearchableDropdownSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71A5287085B2F124BD70276 /* SearchableDropdownSelector.swift */; };
-		172A560DB5500F5442B6AC36 /* OrchestratedDocumentVerificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131D2F4B17C7D3290DD50EA2 /* OrchestratedDocumentVerificationViewModel.swift */; };
-		1D092C3F41774E9B37CDE7B8 /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56CBC49567302AE486C6380D /* NavigationBar.swift */; };
-		1DA22148C9D4B6B268DD8665 /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F0C9B5FFB8AA00CD13C1B7 /* Injected.swift */; };
-		1DA70AAE250F9D665DE4F6FF /* DependencyAutoResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8336425A8244E777C8168F5C /* DependencyAutoResolver.swift */; };
+		1678F555BFD395B2D65148F6 /* RectangleDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7C55CAAC288E619AFD48B7 /* RectangleDetector.swift */; };
+		19D8E2ED7DC7021EB2B8EB3D /* ImageCaptureConfirmationDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA4F7C3D326E512B2E492A6 /* ImageCaptureConfirmationDialog.swift */; };
 		1E60693A8A4869772CCEC3A7 /* AspectRatioRoundedRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C72AFF8AA3938F339F5DE6 /* AspectRatioRoundedRectangle.swift */; };
-		1ED186D9CDD4A99AD6E59014 /* FaceShapedProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05BA2F5499BFBDDC3E73064C /* FaceShapedProgressIndicator.swift */; };
 		1ED676C92B5983C30046CE46 /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = 1ED676C82B5983C30046CE46 /* Zip */; };
 		1EEFC2252B583CFB00B8A934 /* SmileID.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EEFC21A2B583CFB00B8A934 /* SmileID.framework */; };
 		1EEFC2C72B58412300B8A934 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1EEFC2402B58412200B8A934 /* .swiftlint.yml */; };
@@ -64,160 +62,162 @@
 		1EEFC3C32B5849EA00B8A934 /* DependencyContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEFC3AF2B5849D100B8A934 /* DependencyContainerTests.swift */; };
 		1EEFC3C42B5849EA00B8A934 /* BaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEFC3B02B5849D100B8A934 /* BaseTestCase.swift */; };
 		202719D3BFB6F8E10DC070EF /* NetworkUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AED3EA08FD760DA0C5C159 /* NetworkUtil.swift */; };
+		20BF2027B855E9BDD9DFDE7C /* SmileID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FAFBA133860FEB80AAE2AB5 /* SmileID.swift */; };
 		20F0E923BCA0665D9B4C56FB /* JobType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF14E3CE346EE315BBAA06F5 /* JobType.swift */; };
-		23EBECB61E1EF26FC6491879 /* Transformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C45F4E3F4AA047CE0B74BD /* Transformable.swift */; };
-		23F01494077D7AA4C58ADCBA /* StringConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD65DF6450FEA52B55ABB0B /* StringConstants.swift */; };
-		2419A4DF8068417F49E202A8 /* SmileIDResourcesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E89A3DFE7125210390FFA4A /* SmileIDResourcesHelper.swift */; };
-		259688E5A8EF0D8D0A41E61B /* RestServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFBFF74C516AB624863EFDE /* RestServiceClient.swift */; };
+		23D624670B9009A30BECC772 /* BVN.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53560F9812139E6F893C282 /* BVN.swift */; };
 		25C4BC1BE6584FD89624C928 /* JobSubmittable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75D88AE78D6084933EDB15B /* JobSubmittable.swift */; };
-		27FA3BE66A5FEA4924D8141B /* ServiceHeaderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5414FE925E1B6AFD4F732CF /* ServiceHeaderProvider.swift */; };
+		272B51EE49D39C4AB65AB809 /* DependencyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3AAE335A1066C7EA8DAF7CE /* DependencyResolver.swift */; };
 		284398A61CF8B5006D10A0E3 /* FaceGeometryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF172C83AC18959B5F1986FA /* FaceGeometryModel.swift */; };
+		29A11C12772969D59DFE3861 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60CC438E25A1C5E650930BC /* Util.swift */; };
+		2A81899E4657BDBC9F6D098E /* ValidDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D264A99B640D834AAB0C93 /* ValidDocuments.swift */; };
 		2A8EE65F1961A4571BB15CD4 /* EnhancedKyc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2938B101B2631CA02C382833 /* EnhancedKyc.swift */; };
-		2AA8C1CB2CF079053C6D2E24 /* DependencyRegisterer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD4A07DBD9E3D8CDB2CFFBD /* DependencyRegisterer.swift */; };
-		2D41D5123A089EB24DE378A2 /* UploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CD09A0E3D39035FD651D25 /* UploadRequest.swift */; };
+		2F60973649978BCC01CC58E5 /* DocumentShapedBoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38EFB0C06B7F1ECFDB57A29 /* DocumentShapedBoundingBox.swift */; };
 		30C8F724F0127DDD500BCEBB /* DocumentVerificationResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F52FE87C9F657E3401C5A /* DocumentVerificationResultDelegate.swift */; };
 		3717248CAC00728B9734E68C /* ServiceHeaderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DBABE0DA9A61E289320E64 /* ServiceHeaderProvider.swift */; };
-		38AAC5F02FB8F8D9FA6DF12B /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060F6B584BCC693A67E71049 /* HTTPHeader.swift */; };
 		3B303D1A8B361A0AABC6D74A /* SmileIDService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B43E802E066AABEBFD95DD /* SmileIDService.swift */; };
-		3C5E72AE30FAF0D55C8642C6 /* OrchestratedBiometricKycViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E52F0AA7B45082A1158127 /* OrchestratedBiometricKycViewModel.swift */; };
-		3C881D590D238B6AED8384DD /* DocumentVerificationResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660AEC503BC7F55A23C12511 /* DocumentVerificationResultDelegate.swift */; };
+		3CB4C2330F81DA7FC11FB600 /* SmartSelfieInstructionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AAF579248140D2504A4EAB8 /* SmartSelfieInstructionsScreen.swift */; };
+		3DACEB2D827FA46A2155B856 /* TextDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D27A10B2FEDA57B884CE2C /* TextDetector.swift */; };
 		3F146B9F13BEC7CE4D2AE784 /* SelfieCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319A42474B61895F9D4AE64B /* SelfieCaptureScreen.swift */; };
-		40521D42D77DEDA0538ACFDF /* ServiceRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45232E50CCFF0C28401ED0F /* ServiceRunnable.swift */; };
+		40A0EDB939860E6E3414532C /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869313094012C40C847A8DA7 /* Injected.swift */; };
 		40C99B4F0E94E7A76898DA93 /* ImageCaptureConfirmationDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828C428188F879A3060C9F7A /* ImageCaptureConfirmationDialog.swift */; };
-		40FD1945E1C1093E102EF406 /* SelfieCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65071FF0E436D0EC8C4C9B2F /* SelfieCaptureScreen.swift */; };
-		413584A0DB20B48D08B6B934 /* SmartSelfieInstructionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DEC993DACC7756924707F6 /* SmartSelfieInstructionsScreen.swift */; };
 		423467D5FDACDAC34D677EFF /* RectangleDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D391125F19F14CCFE64CB6C /* RectangleDetector.swift */; };
 		433870D4F7C58C9432868A21 /* StringConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EAFA186D6F61FB7F7C1CF6 /* StringConstants.swift */; };
-		46BB6EA60FBE616F7B08CA45 /* CaptureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF783A0C9218B698B9D5E080 /* CaptureButton.swift */; };
-		46D53B8485917F6EBFE99FCE /* OrchestratedConsentScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B260C5C187AE06FF6469F137 /* OrchestratedConsentScreen.swift */; };
+		4435A31CE11AB9DBB5DFDD1B /* SmartSelfieResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3768E1DF4C52E461D79C44A /* SmartSelfieResultDelegate.swift */; };
+		460156CA2759D18D5DF40EB4 /* ServiceHeaderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF7A52C810A3E90396B2C7F /* ServiceHeaderProvider.swift */; };
+		46C46D364FF39204A3DDA2AA /* InfiniteProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0794E733AF10A0B6507EE12 /* InfiniteProgressBar.swift */; };
 		47AE15B0C5D49410DFE83B47 /* OrchestratedSelfieCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F3052672AC4114131F67D7 /* OrchestratedSelfieCaptureScreen.swift */; };
-		48C8303F0E843B429D1B49C8 /* OrchestratedSelfieCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77973CD590B67DE9B9D2A22 /* OrchestratedSelfieCaptureScreen.swift */; };
-		509CEFA30178BBB779554742 /* LocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31D7E9D6ADDC7BDB67BFE6C /* LocalStorage.swift */; };
+		499A1C6B61680E0E7D5BE123 /* CaptureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1225F850C1DE8F8C0E163F31 /* CaptureButton.swift */; };
+		4A90E41DB56102E9935FAC7D /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FBA7B8AF49080BDFF2FAB1 /* Theme.swift */; };
+		4C50F52829A6A8A16EB0DFE7 /* SmileIDService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF58FED36068A8A8EAE274E /* SmileIDService.swift */; };
+		4CA0E0025B9DE03228DABC81 /* OrchestratedDocumentVerificationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA45274F4EFFAC65DD546FD /* OrchestratedDocumentVerificationScreen.swift */; };
+		4D6238CDBDAC25E6C6C22176 /* URLSessionRestServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DCE137A3CCF5583E7FCFF9 /* URLSessionRestServiceClient.swift */; };
+		509B7EA05CDA9C55EFF2B7A4 /* NetworkUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153AB9A6C99A275245425516 /* NetworkUtil.swift */; };
 		52D9D812215568215D083200 /* DependencyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33582BC06C5A1BF366206851 /* DependencyResolver.swift */; };
+		5541C4BD78990006336E810B /* JobSubmittable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2057840F67E55D1CB5A304 /* JobSubmittable.swift */; };
 		59A6E2C084B5D3A2E5ADC3B5 /* EpilogueFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569F7887148BD143ED7AF657 /* EpilogueFont.swift */; };
-		59A868ABE03FB7FEF706856D /* ImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F169EAE2FED19C3CAC7C0942 /* ImageExtensions.swift */; };
-		59AFDB04C6212B86C09A3962 /* ImageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A8C6C3C96D8D231DBA7F26 /* ImageUtils.swift */; };
 		5B2B787747FCFE4D7005AE12 /* HTTPQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB121D6B221D1F3B5F983F /* HTTPQueryParameters.swift */; };
 		5BEC9952C5C7600E626E4609 /* DocumentShapedBoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E6BC388D272353332F0EF4 /* DocumentShapedBoundingBox.swift */; };
-		5DD5111145DF6870429924CA /* ARViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5208E3D8DA8D54E8002DC6 /* ARViewController.swift */; };
 		5E1C0325508BA451248C82DD /* UploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED654DB7F5089D1879E8235 /* UploadRequest.swift */; };
-		6019D5F3A8012D0EA3ECF953 /* TextDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF6F37459C9BF715FC99A30 /* TextDetector.swift */; };
 		603AB4217275BF8E936B3052 /* PrepUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A20803E7E23997726E5A02 /* PrepUpload.swift */; };
 		611A09933DF15794D832A12D /* SmileIDLocalizableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8D3569C3E6BC1784C807B5 /* SmileIDLocalizableStrings.swift */; };
-		618053D1765363D9ABFF1711 /* FaceDetectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111AD78D4230B0895C6CA064 /* FaceDetectionState.swift */; };
-		61D1F65FC036570FCC995860 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547AB147CBE320E2B2DA86A3 /* DependencyContainer.swift */; };
+		61C413D7E1CB34A7334044A0 /* RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035C45B5DDA568CA2F50D7C1 /* RestRequest.swift */; };
 		63EC3FC56764F3F7A0A66ABE /* OrchestratedConsentScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEB79F66629B4E9E41A3064 /* OrchestratedConsentScreen.swift */; };
 		6499FEF84D503F8C72CDCF4B /* FaceShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D08503403369523E8841D /* FaceShape.swift */; };
+		6597B3F425DAE9E764469943 /* SmileIDResourcesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036936D802EB58EA561358DE /* SmileIDResourcesHelper.swift */; };
+		684BD973F6E6FF0359B8B1AD /* DocumentVerificationResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48ACD7239CE3ADD1FC0CA3CF /* DocumentVerificationResultDelegate.swift */; };
 		687765EDCA8D250D496A56C9 /* CameraError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3FEE1F9CDD209280B1CBB5C /* CameraError.swift */; };
-		68BAA62E18112F59BC922D49 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22818790B5CC4CF336E0C62B /* Util.swift */; };
-		69BDD31220AE6E589DF6EC13 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435AF4D34B67BEF15DB0EB35 /* CameraView.swift */; };
+		69A80F96098F427328D67C89 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA570C41F4DDAA7D98C99FB0 /* ImagePicker.swift */; };
+		69BAA6C270C9F637578D4EBE /* FaceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE1267131888D72E597C057 /* FaceDetector.swift */; };
+		6AF0939F8E7E5887791D6E43 /* JobStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346CCA1D50B64C7E1B21322 /* JobStatus.swift */; };
 		6AF09E71303C95027F9A803D /* InfiniteProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CD0268DF10F21821324F21 /* InfiniteProgressBar.swift */; };
 		6BBB5D74DA61D413181FC5B2 /* SmileIDResourcesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF70843C1A1C9BD65FD2C9E /* SmileIDResourcesHelper.swift */; };
-		6DBA0DEBE0995D29AE830319 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F84BE9AABCE9703F76F06B2 /* Theme.swift */; };
 		6DFC2D7B4F41E78DB6B982A8 /* OrchestratedBiometricKycScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504AE68DC57C62438EB32243 /* OrchestratedBiometricKycScreen.swift */; };
-		6E134DB5AD7C7F2C62FBB8B4 /* SmileIDService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AEED4C5D32FEBDF999EB77 /* SmileIDService.swift */; };
-		72227A22EDB462FDC2944CB6 /* RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E16045BDF6827D0C70F2901 /* RestRequest.swift */; };
-		748A4C0F9555214B5486C03B /* CameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693FCFF9F79384009E6C82A9 /* CameraViewController.swift */; };
-		74E2E88ADD54C15BD5A98A8F /* EnhancedDocumentVerificationResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A796B8DD46775A3005B4C499 /* EnhancedDocumentVerificationResultDelegate.swift */; };
-		76015540BF576B2BB208A747 /* ProcessingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB9063DA4A537DECB635E8D /* ProcessingScreen.swift */; };
+		6EDCE7DDEFDA1040B6EA34B2 /* SearchableDropdownSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5617483BB26266BE9C8BC28 /* SearchableDropdownSelector.swift */; };
+		71BF786F646C0E887D2F2B6E /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889728410F75549D1952ADE4 /* Config.swift */; };
+		7630BEA6AA54E19D0064F2E2 /* OrchestratedDocumentVerificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0089D278C1976B05515DD5AE /* OrchestratedDocumentVerificationViewModel.swift */; };
+		773B1046DC05E6FB1B428BB1 /* DocumentCaptureViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CCB90E04B61E2F9712D55A /* DocumentCaptureViewModel.swift */; };
+		7764A236C7BE2920AAD9BC76 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7112C14F67DA4BAB342EDB1 /* HTTPHeader.swift */; };
 		79833FAB72EB73BF1718DEA8 /* ImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB650CC9A808674747B639C2 /* ImageExtensions.swift */; };
 		7A52C10929CAEE0FC02C2C4F /* CaptureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD452D64185547E327245257 /* CaptureButton.swift */; };
-		7B29DD7AB25B378C01700967 /* EnhancedKyc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5E25360A2520A2276103E6 /* EnhancedKyc.swift */; };
-		7B5CD7D5103C6572CFA33601 /* SmileIDLocalizableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A23632A770BF5F62A7BF74 /* SmileIDLocalizableStrings.swift */; };
-		7D704DEFE7A947EE5DAB6F08 /* ImageCaptureConfirmationDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E749F393E3FA1A15B898BB /* ImageCaptureConfirmationDialog.swift */; };
+		7B90ABB51D216087E51407EF /* ServiceRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6754612C1F5A7931772898 /* ServiceRunnable.swift */; };
 		7FD2EBFDAFB09C9CD77D19D0 /* FontType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AA23159E5820F8D4C205EB /* FontType.swift */; };
-		80A01CABC7BDF7224482D7B0 /* EpilogueFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D2FD8CE67EF087122E772C /* EpilogueFont.swift */; };
-		83CCFE7727286C45F36F2757 /* DocumentCaptureViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B112C4A6BFEBB41AE7B2B3 /* DocumentCaptureViewModel.swift */; };
-		8501D0A3F97A035129CE6A75 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CD1B8B34C15510488ABC5F /* Config.swift */; };
-		856B29086F3CD9A14F5610F1 /* JobStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE2D5D832C5E5A3CA5898B5 /* JobStatus.swift */; };
-		874C9FCB67AB0BF3E9A33584 /* NavigationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D98B60B6563298312AEE569 /* NavigationHelper.swift */; };
-		88BFDF5D8874A60D4123D42A /* FaceGeometryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F510F0E57197DCBC1345CDFD /* FaceGeometryModel.swift */; };
+		80AB81A9B2891E5049480782 /* StringConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA2F1EF4B61DFC0A2C4132B /* StringConstants.swift */; };
+		81374F91F20B60478040EEA8 /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA928B469A4F5374337E2527 /* EnvironmentValues.swift */; };
+		891B7653B1CA059C3AAE6101 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6719B24E9AA936133DFB007 /* CameraManager.swift */; };
 		8A045C11310FE0DCBAB61FE2 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA012C232A0F657C75D15FAC /* CameraView.swift */; };
+		8A873930310EA017D4B3B1DA /* Quadrilateral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57232D62231C6B5B4BCB1428 /* Quadrilateral.swift */; };
 		8B1D053F84AA658B59C355B2 /* DocumentCaptureInstructionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67062D7679EB5CD55BD53E0D /* DocumentCaptureInstructionsScreen.swift */; };
-		8CBF48B7A22C35C641D2CCC9 /* OrchestratedBiometricKycScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86BCC610D8848F8073A91A90 /* OrchestratedBiometricKycScreen.swift */; };
+		8D293D146C020AE0BF0C241D /* PrepUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D758EEF46F8083F17E89809 /* PrepUpload.swift */; };
 		8F449D24B46071C055F445DE /* SelfieViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFDEB16E32E466235C8D561 /* SelfieViewModel.swift */; };
 		8F5469865CDE36209292DF62 /* DependencyAutoResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C5D837186114CE2093E36FB /* DependencyAutoResolver.swift */; };
-		90908F49CFCC67F914824334 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB0EDAF057B56908A695B36 /* ActivityIndicator.swift */; };
+		8F664FFEFE7D8B24CFD2E0E2 /* FaceGeometryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B3CEE3F995092B1812019 /* FaceGeometryModel.swift */; };
+		924EEA7DE40BE422DBD65308 /* HTTPQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EC84FF8A48C56E6B35CC82 /* HTTPQueryParameters.swift */; };
 		9433AF996CA9D998A5D49CD5 /* DocumentCaptureViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1AE35D85102098118F8BBE /* DocumentCaptureViewModel.swift */; };
-		94736EA5E276CE65C60EF030 /* DocumentCaptureInstructionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9467619A93ABD21D0FD85D30 /* DocumentCaptureInstructionsScreen.swift */; };
 		94A8E32BA86735EC8D969F42 /* LocalizedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE79EF146C342833528C540 /* LocalizedStringExtensions.swift */; };
-		95CCD3FE57BABA6B8413D8DB /* RectangleDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B57BB5774AA1456F244735 /* RectangleDetector.swift */; };
+		95CDD1F079266B71EA7B6832 /* ProcessingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DFC0FF5D22CB7A28E7BD03E /* ProcessingScreen.swift */; };
+		96327D0A9A0709DBF07BE82E /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CBEC87BED324042C21F876 /* Colors.swift */; };
 		967477E67AD6E51D4E7EAC97 /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABA2A6E374A76EBAAAA69BF /* NavigationBar.swift */; };
+		96B59A7BBBA22914C38DD574 /* RectangleDectorFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D076AC7EABF859B50983AC1 /* RectangleDectorFunnel.swift */; };
 		97D188E6FC299F76831D99DA /* LocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3368B5FB6AC21FBD01A45B43 /* LocalStorage.swift */; };
-		987134E01BCEE3EB1C6545BB /* URLSessionRestServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9B683438962F7CB298F4F6 /* URLSessionRestServiceClient.swift */; };
+		99B34F1FBAAA18AC5B7344D4 /* DocumentCaptureInstructionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBABC0AFF9FE6BCFCC85EFF /* DocumentCaptureInstructionsScreen.swift */; };
 		9AF0359CD83FE8EA8C022928 /* OrchestratedDocumentVerificationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B326E3749EE0FB08DD90B7E /* OrchestratedDocumentVerificationScreen.swift */; };
 		9B6CFCD8F24A5F8DD7D51EB0 /* URLSessionRestServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFC47EF810BF6E03BD447AE /* URLSessionRestServiceClient.swift */; };
-		9C55DD6AB2087607754F1BFA /* Quadrilateral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705984486EE74D7F5455E8F3 /* Quadrilateral.swift */; };
-		9C9FCA412A6B4C0701FDE75B /* HTTPQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B512D64EA617635DC46D818 /* HTTPQueryParameters.swift */; };
 		9D66F03F17259881CA70595B /* RestartableTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4BDD6DD049B138F0F2DED0 /* RestartableTimer.swift */; };
 		9D7717BB14B4FD93FFA1DFFC /* SmartSelfieInstructionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FD9B3B7648964BDE15DAD /* SmartSelfieInstructionsScreen.swift */; };
+		9E08E2DFC982580E22571A54 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CB83343BE63F407EE9721 /* ActivityIndicator.swift */; };
 		9EE44F3BA81430E9609B6588 /* TextDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8274F2A2D5C46167D8508A1E /* TextDetector.swift */; };
+		9EF9680A731DD159CE103193 /* SmileIDLocalizableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E248E4551E42264204500B /* SmileIDLocalizableStrings.swift */; };
+		9FA3DD0D193EDE05D87F5659 /* DocumentCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2057FBF6B6724BE33B6CC727 /* DocumentCaptureScreen.swift */; };
 		A0A784971DB973689B95EA21 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94058C8DFE03BE4445E3F6EE /* Util.swift */; };
-		A0EEC8E7A0452FC9350A4B25 /* CameraError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E759F9CD89DB0BC152A94141 /* CameraError.swift */; };
-		A1DA37A00D7D7DA82C453680 /* ValidDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61F7BD9B1F3A4EDC4541046 /* ValidDocuments.swift */; };
 		A2707F73239030830B9C096A /* ServiceRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C048561B5993C43541042B9B /* ServiceRunnable.swift */; };
 		A516634CE5638283CAE6B2A2 /* RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C9C5C6243F597728C4E70E /* RestRequest.swift */; };
-		A6BD79A002BB2AE7532BFA49 /* RadioGroupSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C64CF7FEFBFB57DB0241A22 /* RadioGroupSelector.swift */; };
+		A70BED11848EEBE434EDF269 /* LocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D372CD4133F27A2357FC62C /* LocalStorage.swift */; };
+		A8D4E9F6CEBCFF6636664430 /* EpilogueFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD49A1979669D391434BC990 /* EpilogueFont.swift */; };
 		AA5B23450A374D321D055B17 /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1774CBAFEEE57C55BA9FB731 /* EnvironmentValues.swift */; };
 		AB2829252AC87A5E9C877290 /* ProcessingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCCE3F782607A038494EB9E /* ProcessingScreen.swift */; };
-		AB5E9DD40028ECA61571EA0F /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B880075A82D7942253C7B2 /* Colors.swift */; };
-		AC43717BCEFB955ECA13C89E /* DocumentCaptureResultStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2817816615060B13CD8F3322 /* DocumentCaptureResultStore.swift */; };
 		ACC49BFB0CD692F08063ADB6 /* Quadrilateral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759E6844D26802A58B8712B3 /* Quadrilateral.swift */; };
-		AD432228BD0C4AB540D7B735 /* OrchestratedDocumentVerificationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67F80CE93E3F0478587E8E3 /* OrchestratedDocumentVerificationScreen.swift */; };
-		AEF8E4CE5751985EDB8F9F0A /* LocalizedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF30DF41E11C90B80D36B326 /* LocalizedStringExtensions.swift */; };
+		AF1F3C9C81F9926233EDBC80 /* OrchestratedBiometricKycViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09512BAE4AA0BEA998BE625 /* OrchestratedBiometricKycViewModel.swift */; };
 		AF1F51F0CA56E9C892968B0C /* ImageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D187C1487587F647BB70B4B /* ImageUtils.swift */; };
+		AF3625149CC1E70B172BCED0 /* OrchestratedSelfieCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3D4E1F52B5907FF0FEC3FF /* OrchestratedSelfieCaptureScreen.swift */; };
 		B1D2E43B9CAF1511BA0E6776 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7179C52BCFC08D80D0E3AE /* APIError.swift */; };
-		B2CD2585646DA796ED6133D3 /* PartnerParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDFB9ABCE58FB88AE8D2E37 /* PartnerParams.swift */; };
-		B3949CCD064A7DD333C14651 /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FCF9E2DB13225AC5D778F7D /* Services.swift */; };
-		B3A01AC17606C21127DB1673 /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1E3CD7CAC12DA9532E66CE /* EnvironmentValues.swift */; };
-		BBCF657AB79210E01D99424E /* NetworkUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD543353545A6B770DAFBAB8 /* NetworkUtil.swift */; };
-		BBEDD73CAC411DDF62E94CE2 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1DEE5FEB02CBC6C3877721 /* CameraManager.swift */; };
+		B45E839696B5A2536F432166 /* SelfieViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9325CDEF1DD3EDD53E8C8CC2 /* SelfieViewModel.swift */; };
+		B6E8A46BF3DD46A8ABF6E39D /* UploadRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F040378440599FF776A20 /* UploadRequest.swift */; };
+		B811D5DFCD7A8F98AE1F240F /* DependencyRegisterer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA8478FB5FFB2EF71D2BFB /* DependencyRegisterer.swift */; };
 		BC7B9A59C8BB211C86EF1C94 /* SelfieCaptureResultStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1E2B2C8760737EB7D8FF12 /* SelfieCaptureResultStore.swift */; };
-		BD11CACEF204803DB6678B59 /* RectangleDectorFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5EF92F9B293AD46D80EB6 /* RectangleDectorFunnel.swift */; };
-		BD9578010F44750875A3D838 /* BiometricKycResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13B95A10AEE6297C82BE822 /* BiometricKycResultDelegate.swift */; };
+		BCC549DD2D8E743A68288DE4 /* Transformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0120EBC5E6063B54D10270 /* Transformable.swift */; };
+		BDA19FC54581BB8F84CBC6A5 /* ImageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607EC249441CCB39F5C0AA59 /* ImageUtils.swift */; };
 		BDCD4757BAB743EA7551DD0E /* OrchestratedBiometricKycViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818C009D5DA70CA32B2BE792 /* OrchestratedBiometricKycViewModel.swift */; };
-		BFFC5B763C1DEC0BE6C618BC /* URLSessionPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB459A5F8704B6B7AF87A360 /* URLSessionPublisher.swift */; };
+		BF30C6408B811AE443D02B0B /* ImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A972AF39AD9E43DE098D2E2F /* ImageExtensions.swift */; };
 		C059CD0F5C10A5AAD84863DD /* RectangleDectorFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5901A53C0384299C570536 /* RectangleDectorFunnel.swift */; };
+		C06439FCCCA8FAEDA9F940DD /* OrchestratedConsentScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A621FC908F6EBC822569646 /* OrchestratedConsentScreen.swift */; };
+		C1193E04B56751E473207216 /* FaceShapedProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEB6CD1096F226DD2BAFC0D /* FaceShapedProgressIndicator.swift */; };
 		C1893A9507FB641400B47012 /* OrchestratedDocumentVerificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE60DC5DC0B672C7A63EC752 /* OrchestratedDocumentVerificationViewModel.swift */; };
+		C2B0688041FA7B785B53CD28 /* ARViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175212207C6A15C5D10C555 /* ARViewController.swift */; };
+		C308149CE75D38360C85D396 /* FontType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F0A94C924BCCB3DE9CAE81 /* FontType.swift */; };
 		C6F5826E82046E3066991932 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D5576C83969B0585C43EA0 /* Config.swift */; };
+		C881AF5784DF77B819467F4B /* CameraError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902E486A9BF49DC7305E0C4A /* CameraError.swift */; };
 		C9DF6C5C1B47089BC2671705 /* Transformable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D406EA7AFF9B769A32ABC2 /* Transformable.swift */; };
 		CC6062AF38CCE8131A399208 /* DocumentCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2047B0DEBCFE1B9B5A6F8C0 /* DocumentCaptureScreen.swift */; };
 		CC79EA3CFFFF3A4196DE3771 /* URLSessionPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4853AE689089D418579411 /* URLSessionPublisher.swift */; };
-		CC8DE04204943D2BD0516C42 /* DependencyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99BAB86A441CB62F4B58FFE /* DependencyResolver.swift */; };
-		CCBFCF7F749AAF0B79FBF201 /* BVN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555A3B653878FFD66C8125E /* BVN.swift */; };
-		CE7151698E23BF7B1A9E256E /* JobType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E59A66DF8C3D19199A0643 /* JobType.swift */; };
+		CF538DF6233B2B8F1E704602 /* PartnerParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CD5A394AE2F4648C8A89F9 /* PartnerParams.swift */; };
 		D13A6A89009F216C56FFA75B /* FaceShapedProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9ADFD9800EA0646D46B8B41 /* FaceShapedProgressIndicator.swift */; };
-		D2C46F59B04BA3EC08767806 /* SmileID.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEDEB608C4F6FA45B65EAEC /* SmileID.swift */; };
-		D6CD17F517E96D13201A2A94 /* FaceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6F5A55F3319363677B14EC /* FaceDetector.swift */; };
-		D966A21DEA4D17FCD21814C3 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5330194AE8BFEF3111F10441 /* ImagePicker.swift */; };
+		D8A5950EBA40674B7EAE680E /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16C8B77484E4EE044DC81E9 /* Services.swift */; };
+		D8BAFAC40B0D6DA2793505D8 /* CameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DC0780B8908157E94E6AC5 /* CameraViewController.swift */; };
+		D964186FCDA23D07DD254458 /* URLSessionPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CB54CB048501D9BF4406CF /* URLSessionPublisher.swift */; };
 		DBAC4FB4DB2187FE9092F5E4 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1EDF5BA9E1BE42DAD9748D /* ImagePicker.swift */; };
+		DD3D5CD49680452CA9FFFA10 /* JobType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C260279B85AB5E9363A08A3 /* JobType.swift */; };
 		DE18740E9FDEBE1336B99F5E /* DependencyRegisterer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2406FEB60D749A0A5712754A /* DependencyRegisterer.swift */; };
-		DE53A14AED49AAF7B93FA7C3 /* PrepUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB7066DBD4DCF9E68C4DB2 /* PrepUpload.swift */; };
-		E2131AA8D2B55F386FB20454 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FBCC6854ACE74D80ADABB55 /* Authentication.swift */; };
+		DE26C48EA39B3A750DBEFC69 /* LocalizedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580AFDE099C51F7C1B7E8410 /* LocalizedStringExtensions.swift */; };
+		DFB30CE42D584CD582E50CBC /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D302C549E273A69B80C014 /* NavigationBar.swift */; };
+		E172A15938AE33FFFE72342C /* EnhancedDocumentVerificationResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957093C1EFEFE67437FB62DB /* EnhancedDocumentVerificationResultDelegate.swift */; };
 		E3A82D08DE15572BF2230DED /* CameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EB7F80D632884E739C0883 /* CameraViewController.swift */; };
-		E4C7B8E310DCA97C0812BF70 /* RestartableTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDBF7AD96F7A11A88959503 /* RestartableTimer.swift */; };
 		E4D1172132D218D60A7C2C93 /* SmileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6EEF4784E4A3B31C76E379 /* SmileButton.swift */; };
-		E50427D6A894B17F09871009 /* DocumentShapedBoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4228011F99EBE4AD4FEAD4D2 /* DocumentShapedBoundingBox.swift */; };
-		E69555499ACD807D37B01A12 /* SelfieCaptureResultStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FD151A024C9F5E578DD4D1 /* SelfieCaptureResultStore.swift */; };
+		E5C7C5A3FB7314C7F695D44E /* RestartableTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FD976FF184A1BC7FF56197C /* RestartableTimer.swift */; };
 		E95D183BF9026CAE15EB2576 /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA32A51394C07967050A7B6 /* Services.swift */; };
+		E987E111B6E733211C05596F /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DC89BA02FB9EF5FD348368 /* DependencyContainer.swift */; };
 		E9D5571E328717DC51807807 /* ARViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CC886E5B36ED992409141B /* ARViewController.swift */; };
 		E9F9A15A564D921DEE374CD5 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAEC6C8BBA47851A9A17706 /* Colors.swift */; };
 		EA8281CC96085CDEF91672C1 /* EnhancedDocumentVerificationResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC22D88DBBE7F7A576791B38 /* EnhancedDocumentVerificationResultDelegate.swift */; };
 		EB643527182238D2E6093A74 /* SearchableDropdownSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE83EE7EA4BBA2D0583B0F17 /* SearchableDropdownSelector.swift */; };
-		EE1EC028E58C7EEE2B4B5BA4 /* SelfieViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDCC3D3376108BA63E55E80 /* SelfieViewModel.swift */; };
 		EED0E32D2F52BB1AD0E5DD02 /* DocumentCaptureResultStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E8667C9271EE8598B80899 /* DocumentCaptureResultStore.swift */; };
-		EFC158A4AD15EB2F4494850A /* AspectRatioRoundedRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F082EC4B34F21C4D889A267A /* AspectRatioRoundedRectangle.swift */; };
 		F06013811903AD3C011EF267 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9A4717B4C47BE3D1F914AA /* DependencyContainer.swift */; };
+		F0815EC23DBD284D54248F0F /* EnhancedKyc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82B6D757B610513C291388 /* EnhancedKyc.swift */; };
 		F1601A1125D90EF381E8340C /* RestServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8958BA0E66F0CAB8A45203F /* RestServiceClient.swift */; };
-		F4EA8929FC11E6292BEE2C4A /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF84CC3DDF19A1FF641DFC2 /* APIError.swift */; };
+		F3970D00683DA66B634DB5AC /* NavigationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6F2AACC7B5633D65F3C43C /* NavigationHelper.swift */; };
 		F508B0F421EDA78EDE947EBD /* FaceDetectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198BD7560118FFB7AE6362D2 /* FaceDetectionState.swift */; };
-		F5675F01A5EC1B199E78B87F /* JobSubmittable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B168F5DA1196E19F273B56 /* JobSubmittable.swift */; };
+		F55DAFF07CA748BB6B5A1A00 /* FaceShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4300C8643D4A5971B5294941 /* FaceShape.swift */; };
 		F5C1FD4584457AE805D3422C /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3859922DFB35CF87B711A1 /* Theme.swift */; };
-		F8CCFF821576C48613F12E58 /* SmartSelfieResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223BDD14777C090547C460EC /* SmartSelfieResultDelegate.swift */; };
+		F90AEBF81A8CBF60DCD90995 /* OrchestratedBiometricKycScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C940B8AB5449CF8BFA3C27 /* OrchestratedBiometricKycScreen.swift */; };
 		F93390FD1D7668C67CCF2BB3 /* BiometricKycResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102FAD24E19BA567B8CB8498 /* BiometricKycResultDelegate.swift */; };
+		F94A8143B70F0D7A207A2E5D /* DocumentCaptureResultStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0043CD96B3904B3CE36F943 /* DocumentCaptureResultStore.swift */; };
+		FA2AFC322562FBB823E8E62A /* BiometricKycResultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4B656BA8D0E707FDC3772C /* BiometricKycResultDelegate.swift */; };
 		FC0C9C11FE11F23F784F7B03 /* ValidDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10941E016EAA84C96E69A62B /* ValidDocuments.swift */; };
+		FCFF9EC6481CE91DB7F610CA /* RadioGroupSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470BF95962F91E56C6630123 /* RadioGroupSelector.swift */; };
+		FDF540BC212C4AF6E9ED86DC /* SelfieCaptureScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886BD74D81925A487A6D3F09 /* SelfieCaptureScreen.swift */; };
 		FE36BA7DC5538648655640FB /* PartnerParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = D330E1DDB7F23A8B81F92045 /* PartnerParams.swift */; };
 		FF0B4719A1790F71B97CB8D8 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EED012727F90637BCFB392 /* CameraManager.swift */; };
+		FF3DD3BC9F5FE8BCC6B75013 /* SmileButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37116A2193FD09C63FA79BD /* SmileButton.swift */; };
+		FF6D86CAB80D887021C0C4C2 /* SelfieCaptureResultStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9324B5C321B7ECD09482E9B6 /* SelfieCaptureResultStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -248,20 +248,26 @@
 		002FF7131A547756DDA49A1C /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		00327F41FC57DBBBA8802F6F /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		0041B630D3DEE46BF25F0AFF /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
+		0089D278C1976B05515DD5AE /* OrchestratedDocumentVerificationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift; sourceTree = "<group>"; };
 		009035972AF554790B35B961 /* RestartableTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestartableTimer.swift; path = Sources/SmileID/Classes/RestartableTimer.swift; sourceTree = "<group>"; };
 		00AEE0BD7A0EA41F5BFDB6BA /* NavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationBar.swift; path = Sources/SmileID/Classes/Navigation/NavigationBar.swift; sourceTree = "<group>"; };
 		00C591010B1563D0CB90DF8D /* Quadrilateral.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Quadrilateral.swift; path = Sources/SmileID/Classes/RectangleDetector/Quadrilateral.swift; sourceTree = "<group>"; };
 		01267FF8F4E9878C0A2470E8 /* SmartSelfieResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieResultDelegate.swift; path = Sources/SmileID/Classes/SelfieCapture/SmartSelfieResultDelegate.swift; sourceTree = "<group>"; };
 		014EA08D28BB5C9CA4436305 /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyContainer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyContainer.swift; sourceTree = "<group>"; };
 		018327368F4D16605A4DD881 /* EnhancedKyc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedKyc.swift; path = Sources/SmileID/Classes/Networking/Models/EnhancedKyc.swift; sourceTree = "<group>"; };
+		01EA8478FB5FFB2EF71D2BFB /* DependencyRegisterer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyRegisterer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyRegisterer.swift; sourceTree = "<group>"; };
 		021B38A89F03354FA768A07F /* Quadrilateral.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Quadrilateral.swift; path = Sources/SmileID/Classes/RectangleDetector/Quadrilateral.swift; sourceTree = "<group>"; };
 		021FD9B3B7648964BDE15DAD /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		02274811FE6DB837D4BB63F9 /* DocumentCaptureViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift; sourceTree = "<group>"; };
 		0263C2BED16C323D34B969BE /* FontType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FontType.swift; path = Sources/SmileID/Classes/Helpers/FontType.swift; sourceTree = "<group>"; };
 		0294CEC2C837B494FD6C2060 /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
 		02AED3EA08FD760DA0C5C159 /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
+		02CBEC87BED324042C21F876 /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = Sources/SmileID/Classes/Helpers/Colors.swift; sourceTree = "<group>"; };
+		02DC89BA02FB9EF5FD348368 /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyContainer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyContainer.swift; sourceTree = "<group>"; };
 		02EF3F96905B18EBD7E8F1FA /* HTTPQueryParameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPQueryParameters.swift; path = Sources/SmileID/Classes/Networking/HTTPQueryParameters.swift; sourceTree = "<group>"; };
 		035B7EC4E937998758ABFC4C /* JobStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobStatus.swift; path = Sources/SmileID/Classes/Networking/Models/JobStatus.swift; sourceTree = "<group>"; };
+		035C45B5DDA568CA2F50D7C1 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
+		036936D802EB58EA561358DE /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
 		036A92D094B59ADDF4559362 /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
 		036CD67674A9B67D73945CDD /* Injected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injected.swift; path = Sources/SmileID/Classes/DependencyContainer/Injected.swift; sourceTree = "<group>"; };
 		037B02B11CA0D4770BF47144 /* OrchestratedSelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedSelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/OrchestratedSelfieCaptureScreen.swift; sourceTree = "<group>"; };
@@ -269,6 +275,7 @@
 		038AAC0D6E2DE4C6E95E5A11 /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
 		039445839646A229930F9DF6 /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		03FB2483656D7FF0D709362D /* FaceDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetector.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetector.swift; sourceTree = "<group>"; };
+		03FF7E77C168337E221826F5 /* AspectRatioRoundedRectangle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AspectRatioRoundedRectangle.swift; path = Sources/SmileID/Classes/Views/AspectRatioRoundedRectangle.swift; sourceTree = "<group>"; };
 		042968EC070187BDC43DC72D /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
 		04686E60DFC6100D94B9F682 /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
 		04A423E23B27BBD2CD14C74F /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
@@ -281,8 +288,10 @@
 		0574AE194DB53544A123DD6C /* AspectRatioRoundedRectangle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AspectRatioRoundedRectangle.swift; path = Sources/SmileID/Classes/Views/AspectRatioRoundedRectangle.swift; sourceTree = "<group>"; };
 		05B43E802E066AABEBFD95DD /* SmileIDService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDService.swift; path = Sources/SmileID/Classes/Networking/SmileIDService.swift; sourceTree = "<group>"; };
 		05BA2F5499BFBDDC3E73064C /* FaceShapedProgressIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShapedProgressIndicator.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShapedProgressIndicator.swift; sourceTree = "<group>"; };
+		05EC84FF8A48C56E6B35CC82 /* HTTPQueryParameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPQueryParameters.swift; path = Sources/SmileID/Classes/Networking/HTTPQueryParameters.swift; sourceTree = "<group>"; };
 		060A5C6D5050CB8D216842CC /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
 		060F6B584BCC693A67E71049 /* HTTPHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPHeader.swift; path = Sources/SmileID/Classes/Networking/HTTPHeader.swift; sourceTree = "<group>"; };
+		06105CBE10AACF8136C7E31A /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
 		0643F2B573C96F21294D9557 /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
 		06558CC9C4B88017F972502C /* Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = Sources/SmileID/Classes/Networking/Models/Authentication.swift; sourceTree = "<group>"; };
 		068B5B519949E3D3B2F8A7A4 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
@@ -292,6 +301,7 @@
 		06BB8337DA8DF78C7E28787E /* Transformable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Transformable.swift; path = Sources/SmileID/Classes/RectangleDetector/Transformable.swift; sourceTree = "<group>"; };
 		06C982B0F5671DE8D83ABC1E /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		06CFAF3130547A99DB575D09 /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
+		06F0A94C924BCCB3DE9CAE81 /* FontType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FontType.swift; path = Sources/SmileID/Classes/Helpers/FontType.swift; sourceTree = "<group>"; };
 		06F21D980A5E80AC5D92D36B /* Transformable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Transformable.swift; path = Sources/SmileID/Classes/RectangleDetector/Transformable.swift; sourceTree = "<group>"; };
 		07099E282E34145D6F733C41 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		071A8F48DB6C1A39965EAB00 /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
@@ -366,6 +376,7 @@
 		0E9AEED12A441BDE65D03A3E /* OrchestratedDocumentVerificationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift; sourceTree = "<group>"; };
 		0EBAF58E471D0BCC14688943 /* ActivityIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ActivityIndicator.swift; path = Sources/SmileID/Classes/Views/ActivityIndicator.swift; sourceTree = "<group>"; };
 		0ECD3D4FE4860C99F4B8AE50 /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
+		0EE1267131888D72E597C057 /* FaceDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetector.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetector.swift; sourceTree = "<group>"; };
 		0EF1688C631F0F19803A89FB /* ServiceRunnable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceRunnable.swift; path = Sources/SmileID/Classes/Networking/ServiceRunnable.swift; sourceTree = "<group>"; };
 		0F1D3CC050F3C2A3EAFEA678 /* DocumentCaptureViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift; sourceTree = "<group>"; };
 		0F32E3B02FB6EFF14149FA26 /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
@@ -375,6 +386,7 @@
 		0FA379536E7961A3465AA94F /* OrchestratedDocumentVerificationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift; sourceTree = "<group>"; };
 		0FA98ECD614EECF53E1D250E /* ServiceHeaderProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceHeaderProvider.swift; path = Sources/SmileID/Classes/Networking/ServiceHeaderProvider.swift; sourceTree = "<group>"; };
 		0FCF9E2DB13225AC5D778F7D /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
+		0FD976FF184A1BC7FF56197C /* RestartableTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestartableTimer.swift; path = Sources/SmileID/Classes/RestartableTimer.swift; sourceTree = "<group>"; };
 		0FF9F41478E4BAE0014C302D /* OrchestratedDocumentVerificationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift; sourceTree = "<group>"; };
 		102FAD24E19BA567B8CB8498 /* BiometricKycResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricKycResultDelegate.swift; path = Sources/SmileID/Classes/BiometricKYC/BiometricKycResultDelegate.swift; sourceTree = "<group>"; };
 		1047F50F611480CC2B06623F /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
@@ -390,14 +402,17 @@
 		11EED012727F90637BCFB392 /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
 		11FBA20F1CC77E1EB1138213 /* URLSessionPublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionPublisher.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionPublisher.swift; sourceTree = "<group>"; };
 		120878104C0FAF042D3CEDC4 /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
+		1225F850C1DE8F8C0E163F31 /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
 		12370699D417E59C8AE9A413 /* DependencyResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyResolver.swift; sourceTree = "<group>"; };
 		1256B4084DB833C62B4840A8 /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
 		126F8B41AEF730C789811FCE /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
 		1298C2D7DEF959BCC87DC663 /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
+		12CB54CB048501D9BF4406CF /* URLSessionPublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionPublisher.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionPublisher.swift; sourceTree = "<group>"; };
 		12D470CADCFEE3153A48CBC8 /* FaceShape.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShape.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShape.swift; sourceTree = "<group>"; };
 		12DA5C6D0AB065FA59C4DC60 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		12E749F393E3FA1A15B898BB /* ImageCaptureConfirmationDialog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageCaptureConfirmationDialog.swift; path = Sources/SmileID/Classes/Views/ImageCaptureConfirmationDialog.swift; sourceTree = "<group>"; };
 		12EFB27946F557D595822717 /* LocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalStorage.swift; path = Sources/SmileID/Classes/Helpers/LocalStorage.swift; sourceTree = "<group>"; };
+		130CB83343BE63F407EE9721 /* ActivityIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ActivityIndicator.swift; path = Sources/SmileID/Classes/Views/ActivityIndicator.swift; sourceTree = "<group>"; };
 		131BAF2CE0AD843302FBA78D /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		131D2F4B17C7D3290DD50EA2 /* OrchestratedDocumentVerificationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift; sourceTree = "<group>"; };
 		1323BF1BB6A734244B12BE21 /* SelfieCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureResultStore.swift; path = Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureResultStore.swift; sourceTree = "<group>"; };
@@ -410,11 +425,13 @@
 		148D14B74B6DEA093EC5D8B2 /* SelfieViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieViewModel.swift; path = Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift; sourceTree = "<group>"; };
 		1490914A74E6950FBD3A8B59 /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		149272E3046DAA6C5F361BF7 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
+		14D27A10B2FEDA57B884CE2C /* TextDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextDetector.swift; path = Sources/SmileID/Classes/DocumentVerification/TextDetector/TextDetector.swift; sourceTree = "<group>"; };
 		14E9DF70FC0E737D8544C4A8 /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
 		151F50D7B2814DAD0DA5CB17 /* AspectRatioRoundedRectangle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AspectRatioRoundedRectangle.swift; path = Sources/SmileID/Classes/Views/AspectRatioRoundedRectangle.swift; sourceTree = "<group>"; };
 		15371BBBE18437EDDC517CE0 /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
 		153835EC923C317AAEA96277 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
 		1539CF743B0B9D0650FDA0DC /* ImageExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageExtensions.swift; path = Sources/SmileID/Classes/Helpers/ImageExtensions.swift; sourceTree = "<group>"; };
+		153AB9A6C99A275245425516 /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
 		1543F354CFB9D253F76E360F /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
 		155F31C96420A4B7666EC777 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
 		158B29EABD8D951E646C43A2 /* DependencyRegisterer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyRegisterer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyRegisterer.swift; sourceTree = "<group>"; };
@@ -623,6 +640,7 @@
 		1FEFA9F43D292DCA8A292A34 /* FontType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FontType.swift; path = Sources/SmileID/Classes/Helpers/FontType.swift; sourceTree = "<group>"; };
 		2015356900AF8C78B4B37110 /* ServiceRunnable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceRunnable.swift; path = Sources/SmileID/Classes/Networking/ServiceRunnable.swift; sourceTree = "<group>"; };
 		204E25AA87E9519F31645909 /* DocumentCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift; sourceTree = "<group>"; };
+		2057FBF6B6724BE33B6CC727 /* DocumentCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift; sourceTree = "<group>"; };
 		208563C91ED929072F239DE9 /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		209BE3605849ED55515BE4BF /* OrchestratedDocumentVerificationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift; sourceTree = "<group>"; };
 		20BD76F142CABEAE07EF1F67 /* SmileIDService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDService.swift; path = Sources/SmileID/Classes/Networking/SmileIDService.swift; sourceTree = "<group>"; };
@@ -743,6 +761,7 @@
 		2D33685D695F8D43023AC031 /* DocumentCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift; sourceTree = "<group>"; };
 		2D5E0403771C4391EAE36763 /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
 		2D7FC2CD03E3F53D52B4D605 /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
+		2DBABC0AFF9FE6BCFCC85EFF /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		2DFE65899FB5E8C5C883DFBD /* SmileButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileButton.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift; sourceTree = "<group>"; };
 		2E3878B306C22DCA2FA75BC0 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
 		2E41676BEEAD8392FF63FA8D /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
@@ -756,6 +775,7 @@
 		2F7179C52BCFC08D80D0E3AE /* APIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIError.swift; path = Sources/SmileID/Classes/Networking/APIError.swift; sourceTree = "<group>"; };
 		2F8B1D550F6F5D398D1FC993 /* DocumentCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureResultStore.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureResultStore.swift; sourceTree = "<group>"; };
 		2FA09816729C7033F8327A18 /* ARViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ARViewController.swift; path = Sources/SmileID/Classes/SelfieCapture/View/ARViewController.swift; sourceTree = "<group>"; };
+		2FAFBA133860FEB80AAE2AB5 /* SmileID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileID.swift; path = Sources/SmileID/Classes/SmileID.swift; sourceTree = "<group>"; };
 		2FCF11BE2BA6E0E9E440BDE8 /* APIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIError.swift; path = Sources/SmileID/Classes/Networking/APIError.swift; sourceTree = "<group>"; };
 		2FE3CA8A10C481CE110F92FD /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		2FE5BEF5F8FF44A6A65CB765 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
@@ -774,6 +794,7 @@
 		31193D37AE0BEDF13941D076 /* SmileIDLocalizableStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDLocalizableStrings.swift; path = Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift; sourceTree = "<group>"; };
 		31522D4052E1136FF989D824 /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
 		316A7B3ABDC4F1E6CF5F8E6E /* ProcessingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProcessingScreen.swift; path = Sources/SmileID/Classes/Views/ProcessingScreen.swift; sourceTree = "<group>"; };
+		3175212207C6A15C5D10C555 /* ARViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ARViewController.swift; path = Sources/SmileID/Classes/SelfieCapture/View/ARViewController.swift; sourceTree = "<group>"; };
 		319568F790F8CBFD0D5C69AB /* FontType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FontType.swift; path = Sources/SmileID/Classes/Helpers/FontType.swift; sourceTree = "<group>"; };
 		319A42474B61895F9D4AE64B /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		31ADC2E0D5A31DA83E073EC9 /* PrepUpload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrepUpload.swift; path = Sources/SmileID/Classes/Networking/Models/PrepUpload.swift; sourceTree = "<group>"; };
@@ -843,10 +864,12 @@
 		39A1F256588BAFDCDA2E4128 /* FaceShapedProgressIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShapedProgressIndicator.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShapedProgressIndicator.swift; sourceTree = "<group>"; };
 		39A9EBE001763CBABFBC6612 /* URLSessionRestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionRestServiceClient.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift; sourceTree = "<group>"; };
 		39B3012C10872F01AE62A889 /* UploadRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UploadRequest.swift; path = Sources/SmileID/Classes/Networking/Models/UploadRequest.swift; sourceTree = "<group>"; };
+		39E248E4551E42264204500B /* SmileIDLocalizableStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDLocalizableStrings.swift; path = Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift; sourceTree = "<group>"; };
 		39EDC7C94AA0F731D0510265 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
 		39F2CB9CDBF74EA941F11AEA /* SelfieCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureResultStore.swift; path = Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureResultStore.swift; sourceTree = "<group>"; };
 		39FFD9B67C18D194EAA52B2A /* APIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIError.swift; path = Sources/SmileID/Classes/Networking/APIError.swift; sourceTree = "<group>"; };
 		3A0BA3F6877C2D6FC22283B1 /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
+		3A621FC908F6EBC822569646 /* OrchestratedConsentScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedConsentScreen.swift; path = Sources/SmileID/Classes/Consent/OrchestratedConsentScreen.swift; sourceTree = "<group>"; };
 		3AA066A0F16AC0E8FFB52556 /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
 		3AD6F22C1F1B1836F734550A /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
 		3AFBFF74C516AB624863EFDE /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
@@ -854,6 +877,7 @@
 		3B15B745C6A01E74DCD8BF39 /* InfiniteProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteProgressBar.swift; path = Sources/SmileID/Classes/SelfieCapture/View/InfiniteProgressBar.swift; sourceTree = "<group>"; };
 		3B760C043015272C7A76D782 /* ServiceHeaderProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceHeaderProvider.swift; path = Sources/SmileID/Classes/Networking/ServiceHeaderProvider.swift; sourceTree = "<group>"; };
 		3B9521422403A9C35E5D72C8 /* SmileButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileButton.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift; sourceTree = "<group>"; };
+		3BA45274F4EFFAC65DD546FD /* OrchestratedDocumentVerificationScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift; sourceTree = "<group>"; };
 		3C54D4098BF791F2B1876CB2 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		3C64CF7FEFBFB57DB0241A22 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
 		3C8A3B7EF2B8351E532B6AFC /* OrchestratedConsentScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedConsentScreen.swift; path = Sources/SmileID/Classes/Consent/OrchestratedConsentScreen.swift; sourceTree = "<group>"; };
@@ -908,6 +932,7 @@
 		42543C9D561B5A7D86783005 /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		429F54573010181A4F39DC22 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
 		42E59811DEA510AE16AFA9D4 /* DocumentCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureResultStore.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureResultStore.swift; sourceTree = "<group>"; };
+		4300C8643D4A5971B5294941 /* FaceShape.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShape.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShape.swift; sourceTree = "<group>"; };
 		43066F2432297D0400146BD5 /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		431D683324A582FB99C5C103 /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		43242F054D2397FB858092BD /* ImageExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageExtensions.swift; path = Sources/SmileID/Classes/Helpers/ImageExtensions.swift; sourceTree = "<group>"; };
@@ -939,11 +964,13 @@
 		46BBC319C519DFA38C731F00 /* EnhancedDocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		46C9AEC7BED3A933E57681A0 /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
 		46F0465FD3DA2CE6859EB059 /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
+		470BF95962F91E56C6630123 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
 		471C9C4BC770B46AA9E3EB14 /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		474B781EA56636173AEE74EA /* CameraError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraError.swift; path = Sources/SmileID/Classes/Camera/CameraError.swift; sourceTree = "<group>"; };
 		474DBB65669CA2D41216F071 /* SmartSelfieResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieResultDelegate.swift; path = Sources/SmileID/Classes/SelfieCapture/SmartSelfieResultDelegate.swift; sourceTree = "<group>"; };
 		47982EDF00C37A50135B97FE /* JobStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobStatus.swift; path = Sources/SmileID/Classes/Networking/Models/JobStatus.swift; sourceTree = "<group>"; };
 		484BFEE48FA2EA00878A5409 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
+		48ACD7239CE3ADD1FC0CA3CF /* DocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		48AD5499FA76250ED3B5B5ED /* JobStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobStatus.swift; path = Sources/SmileID/Classes/Networking/Models/JobStatus.swift; sourceTree = "<group>"; };
 		48B5C7DF9BA4BCDD897B3A42 /* ValidDocuments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ValidDocuments.swift; path = Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift; sourceTree = "<group>"; };
 		4908791BE5911C292A935B6E /* InfiniteProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteProgressBar.swift; path = Sources/SmileID/Classes/SelfieCapture/View/InfiniteProgressBar.swift; sourceTree = "<group>"; };
@@ -956,6 +983,7 @@
 		49F2143A8D8FD2FAABC3BBFD /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
 		4A4AEF7893F9D5D5259483D9 /* BiometricKycResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricKycResultDelegate.swift; path = Sources/SmileID/Classes/BiometricKYC/BiometricKycResultDelegate.swift; sourceTree = "<group>"; };
 		4A7FB2EBC3B8AEBABFC8C074 /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
+		4A82B6D757B610513C291388 /* EnhancedKyc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedKyc.swift; path = Sources/SmileID/Classes/Networking/Models/EnhancedKyc.swift; sourceTree = "<group>"; };
 		4A933D4679B80D9127CB3FA6 /* DocumentCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift; sourceTree = "<group>"; };
 		4AB47121053882BCC59CAEA6 /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		4ABE5E4A110B111CE52B759A /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
@@ -977,14 +1005,17 @@
 		4C9E66E42A5ED1B22451F89D /* BiometricKycResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricKycResultDelegate.swift; path = Sources/SmileID/Classes/BiometricKYC/BiometricKycResultDelegate.swift; sourceTree = "<group>"; };
 		4CC4DB22929D6C5F2C5A0802 /* RestartableTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestartableTimer.swift; path = Sources/SmileID/Classes/RestartableTimer.swift; sourceTree = "<group>"; };
 		4D53CD2C3B8C190B92B0C0C2 /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
+		4D758EEF46F8083F17E89809 /* PrepUpload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrepUpload.swift; path = Sources/SmileID/Classes/Networking/Models/PrepUpload.swift; sourceTree = "<group>"; };
 		4D78E5E8F1FB60C28D5D0413 /* DocumentCaptureViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift; sourceTree = "<group>"; };
 		4D7941D68E99A967B61828A2 /* DocumentCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift; sourceTree = "<group>"; };
+		4DA4F7C3D326E512B2E492A6 /* ImageCaptureConfirmationDialog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageCaptureConfirmationDialog.swift; path = Sources/SmileID/Classes/Views/ImageCaptureConfirmationDialog.swift; sourceTree = "<group>"; };
 		4DA9247ECC1B1FC53BABD6AB /* UploadRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UploadRequest.swift; path = Sources/SmileID/Classes/Networking/Models/UploadRequest.swift; sourceTree = "<group>"; };
 		4E104FDF8C242977FA03F2D9 /* DependencyResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyResolver.swift; sourceTree = "<group>"; };
 		4E1BF455415273B80DA95595 /* LocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalStorage.swift; path = Sources/SmileID/Classes/Helpers/LocalStorage.swift; sourceTree = "<group>"; };
 		4E269C1C402DB50FC1343C17 /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		4E290F0CAC795D75B5BC8F82 /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		4E39C1452BCAC9B394956C0C /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
+		4E3D4E1F52B5907FF0FEC3FF /* OrchestratedSelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedSelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/OrchestratedSelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		4E5C6CECB2F459B9F6851E7F /* HTTPQueryParameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPQueryParameters.swift; path = Sources/SmileID/Classes/Networking/HTTPQueryParameters.swift; sourceTree = "<group>"; };
 		4E791EDD7EDE07A88D3E69B1 /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
 		4E813DE6C5C3D5B659AF58EC /* LocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalStorage.swift; path = Sources/SmileID/Classes/Helpers/LocalStorage.swift; sourceTree = "<group>"; };
@@ -1057,6 +1088,7 @@
 		56AD16851171294603D1D5FE /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		56B523217F6E6A23618A2CEC /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		56CBC49567302AE486C6380D /* NavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationBar.swift; path = Sources/SmileID/Classes/Navigation/NavigationBar.swift; sourceTree = "<group>"; };
+		57232D62231C6B5B4BCB1428 /* Quadrilateral.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Quadrilateral.swift; path = Sources/SmileID/Classes/RectangleDetector/Quadrilateral.swift; sourceTree = "<group>"; };
 		576B661F32D1EB8E1D5EBB24 /* AspectRatioRoundedRectangle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AspectRatioRoundedRectangle.swift; path = Sources/SmileID/Classes/Views/AspectRatioRoundedRectangle.swift; sourceTree = "<group>"; };
 		57C40F1AFD4409E7C9B9A905 /* OrchestratedDocumentVerificationScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift; sourceTree = "<group>"; };
 		57D2F84B4A6904BF4C9B331C /* EnhancedDocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
@@ -1064,6 +1096,7 @@
 		57E1F0E5B2478FA775F1A48B /* EnhancedDocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		57EDD92E5CA120EEB9CB2B04 /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
 		580583D45BD6021D8B5E98D6 /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
+		580AFDE099C51F7C1B7E8410 /* LocalizedStringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedStringExtensions.swift; path = Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift; sourceTree = "<group>"; };
 		5817992550DC9FCB3C9426FB /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
 		58185A4E9CDC79CE182ED7CB /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
 		584A51B9274189B7B98CA85D /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
@@ -1101,6 +1134,7 @@
 		5C61DF7867EF5DC740C737D6 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		5C76BD73CD9E5E2724EE5DBB /* SelfieCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureResultStore.swift; path = Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureResultStore.swift; sourceTree = "<group>"; };
 		5C9FC56F7C1C50FECED51DF1 /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
+		5CA2F1EF4B61DFC0A2C4132B /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		5CAA4B145D3A3D3705C2AA15 /* HTTPQueryParameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPQueryParameters.swift; path = Sources/SmileID/Classes/Networking/HTTPQueryParameters.swift; sourceTree = "<group>"; };
 		5CBAA72FEB4E3028D9000797 /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
 		5CCE7918689E5F3CD690FA05 /* TextDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextDetector.swift; path = Sources/SmileID/Classes/DocumentVerification/TextDetector/TextDetector.swift; sourceTree = "<group>"; };
@@ -1115,6 +1149,7 @@
 		5D98B60B6563298312AEE569 /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		5DD26B0B824BCF18ACC72C77 /* HTTPHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPHeader.swift; path = Sources/SmileID/Classes/Networking/HTTPHeader.swift; sourceTree = "<group>"; };
 		5DEB23CFD15D148C14737562 /* EpilogueFont.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EpilogueFont.swift; path = Sources/SmileID/Classes/Helpers/EpilogueFont.swift; sourceTree = "<group>"; };
+		5DFC0FF5D22CB7A28E7BD03E /* ProcessingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProcessingScreen.swift; path = Sources/SmileID/Classes/Views/ProcessingScreen.swift; sourceTree = "<group>"; };
 		5E3E754539144A48A041CFFF /* Quadrilateral.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Quadrilateral.swift; path = Sources/SmileID/Classes/RectangleDetector/Quadrilateral.swift; sourceTree = "<group>"; };
 		5F147F948E04C6C3A0A52D39 /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
 		5F3BB76F967DDB272CC6820A /* SelfieViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieViewModel.swift; path = Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift; sourceTree = "<group>"; };
@@ -1130,6 +1165,7 @@
 		60209CEB9F214D98D33308E3 /* JobStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobStatus.swift; path = Sources/SmileID/Classes/Networking/Models/JobStatus.swift; sourceTree = "<group>"; };
 		6047032B60BE9EDE06343B7D /* ProcessingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProcessingScreen.swift; path = Sources/SmileID/Classes/Views/ProcessingScreen.swift; sourceTree = "<group>"; };
 		6047B9BAD9F380D269CEF36F /* URLSessionPublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionPublisher.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionPublisher.swift; sourceTree = "<group>"; };
+		607EC249441CCB39F5C0AA59 /* ImageUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageUtils.swift; path = Sources/SmileID/Classes/Helpers/ImageUtils.swift; sourceTree = "<group>"; };
 		60CE45DEEF536F177059EDAB /* CameraError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraError.swift; path = Sources/SmileID/Classes/Camera/CameraError.swift; sourceTree = "<group>"; };
 		611B0CBF18319B58D5D89E8D /* Theme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Theme.swift; path = Sources/SmileID/Classes/Helpers/Theme.swift; sourceTree = "<group>"; };
 		612B22661FC80EDF3EA67074 /* CameraError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraError.swift; path = Sources/SmileID/Classes/Camera/CameraError.swift; sourceTree = "<group>"; };
@@ -1144,6 +1180,7 @@
 		632C54284C3E42BBE06B17E2 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		63536E51B5B390C5B878A6F1 /* URLSessionRestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionRestServiceClient.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift; sourceTree = "<group>"; };
 		635FE1B0E58159F477C188F9 /* InfiniteProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteProgressBar.swift; path = Sources/SmileID/Classes/SelfieCapture/View/InfiniteProgressBar.swift; sourceTree = "<group>"; };
+		636B3CEE3F995092B1812019 /* FaceGeometryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceGeometryModel.swift; path = Sources/SmileID/Classes/FaceDetector/FaceGeometryModel.swift; sourceTree = "<group>"; };
 		637117FB32770893EBE1FF69 /* Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = Sources/SmileID/Classes/Networking/Models/Authentication.swift; sourceTree = "<group>"; };
 		63BA7DC5FC07F70D0456063C /* SmileID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileID.swift; path = Sources/SmileID/Classes/SmileID.swift; sourceTree = "<group>"; };
 		63BF76250E0EEA69882D3414 /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
@@ -1190,6 +1227,7 @@
 		682BFFABCA153C8A07870AF0 /* Theme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Theme.swift; path = Sources/SmileID/Classes/Helpers/Theme.swift; sourceTree = "<group>"; };
 		68B00081A319611DE82F295E /* LocalizedStringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedStringExtensions.swift; path = Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift; sourceTree = "<group>"; };
 		68BB856D972B09DE77920C05 /* SmileID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileID.swift; path = Sources/SmileID/Classes/SmileID.swift; sourceTree = "<group>"; };
+		68D264A99B640D834AAB0C93 /* ValidDocuments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ValidDocuments.swift; path = Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift; sourceTree = "<group>"; };
 		693FCFF9F79384009E6C82A9 /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
 		69AAE5399DD0C777FEA9A0EF /* SmileButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileButton.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift; sourceTree = "<group>"; };
 		69B9D562718E6E81AA86E3A3 /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
@@ -1219,10 +1257,12 @@
 		6BAE20D478DD83BF10E71B4A /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		6BDB229B99E1362CD28DABA6 /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
 		6BFC95AEB68A0C456547678D /* Injected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injected.swift; path = Sources/SmileID/Classes/DependencyContainer/Injected.swift; sourceTree = "<group>"; };
+		6C260279B85AB5E9363A08A3 /* JobType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobType.swift; path = Sources/SmileID/Classes/Networking/Models/JobType.swift; sourceTree = "<group>"; };
 		6C63177A91F1CE550D620180 /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
 		6CA254AE3BDA89550533D10F /* SmileButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileButton.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift; sourceTree = "<group>"; };
 		6CFB4243A7BCBC56633F7E17 /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		6D29D92B776F0CABDB20D097 /* LocalizedStringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedStringExtensions.swift; path = Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift; sourceTree = "<group>"; };
+		6D372CD4133F27A2357FC62C /* LocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalStorage.swift; path = Sources/SmileID/Classes/Helpers/LocalStorage.swift; sourceTree = "<group>"; };
 		6D54CFE179F9193DAE0AC0E6 /* ImageExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageExtensions.swift; path = Sources/SmileID/Classes/Helpers/ImageExtensions.swift; sourceTree = "<group>"; };
 		6DAE16F7D9F8019204E03AB8 /* SmileButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileButton.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift; sourceTree = "<group>"; };
 		6DC2AB247C43DA56888E8E23 /* SelfieViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieViewModel.swift; path = Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift; sourceTree = "<group>"; };
@@ -1325,8 +1365,10 @@
 		7A03ACD8533C6A0D9D10F66D /* RectangleDectorFunnel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDectorFunnel.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDectorFunnel.swift; sourceTree = "<group>"; };
 		7A22A6F521845B5EF906350C /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		7A88A90051105B8494BEBE23 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
+		7AAF579248140D2504A4EAB8 /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		7ABADDC849700403A90D8DF3 /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
 		7ADF3909271ED98374BEA291 /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
+		7AF7A52C810A3E90396B2C7F /* ServiceHeaderProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceHeaderProvider.swift; path = Sources/SmileID/Classes/Networking/ServiceHeaderProvider.swift; sourceTree = "<group>"; };
 		7B0376B39C1628D19FC23785 /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
 		7B0BE20E400C3D7DD753451F /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
 		7B199EDC98FDF378B68E70EC /* ProcessingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProcessingScreen.swift; path = Sources/SmileID/Classes/Views/ProcessingScreen.swift; sourceTree = "<group>"; };
@@ -1336,6 +1378,7 @@
 		7B9A810E7C22F09789F03329 /* ServiceHeaderProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceHeaderProvider.swift; path = Sources/SmileID/Classes/Networking/ServiceHeaderProvider.swift; sourceTree = "<group>"; };
 		7BC3FA015D9AE2BAEF8BB7F3 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
 		7BFB1139E38272CBFA301DD7 /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
+		7C7A459BDE41CD5A574427BF /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
 		7CDCC3D3376108BA63E55E80 /* SelfieViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieViewModel.swift; path = Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift; sourceTree = "<group>"; };
 		7CF389E575E2FBFA2C77B420 /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
 		7CF7A5DEA57E97D1FA35461E /* DocumentCaptureViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift; sourceTree = "<group>"; };
@@ -1419,6 +1462,7 @@
 		86511C3C6D657583E4160064 /* CameraView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraView.swift; path = Sources/SmileID/Classes/SelfieCapture/View/CameraView.swift; sourceTree = "<group>"; };
 		868885C7A087B537116774E7 /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
 		8692A1E77DA0029ADFF5722D /* OrchestratedSelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedSelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/OrchestratedSelfieCaptureScreen.swift; sourceTree = "<group>"; };
+		869313094012C40C847A8DA7 /* Injected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injected.swift; path = Sources/SmileID/Classes/DependencyContainer/Injected.swift; sourceTree = "<group>"; };
 		86BCC610D8848F8073A91A90 /* OrchestratedBiometricKycScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycScreen.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift; sourceTree = "<group>"; };
 		86C82FE2B57EB059CED91059 /* OrchestratedDocumentVerificationScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift; sourceTree = "<group>"; };
 		872DDDA3A1B2001AEC05A853 /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
@@ -1432,8 +1476,10 @@
 		87FEA00E1524D299B8DC9034 /* Injected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injected.swift; path = Sources/SmileID/Classes/DependencyContainer/Injected.swift; sourceTree = "<group>"; };
 		88143A24C47EECA1DA26067A /* URLSessionRestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionRestServiceClient.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift; sourceTree = "<group>"; };
 		884546298E3015F72FD443AB /* SmileID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileID.swift; path = Sources/SmileID/Classes/SmileID.swift; sourceTree = "<group>"; };
+		886BD74D81925A487A6D3F09 /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		88738F83C55DA25DB1BA0559 /* CameraError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraError.swift; path = Sources/SmileID/Classes/Camera/CameraError.swift; sourceTree = "<group>"; };
 		8876AD3913A50EB244980F75 /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyContainer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyContainer.swift; sourceTree = "<group>"; };
+		889728410F75549D1952ADE4 /* Config.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Config.swift; path = Sources/SmileID/Classes/Networking/Models/Config.swift; sourceTree = "<group>"; };
 		891445ADB5E1F3F9D31E0F8F /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		89476C1307676C5F5658644C /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
 		896185CDBB2284FD117CFB05 /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
@@ -1446,6 +1492,7 @@
 		89F962C8A5B94E0BF2F4F996 /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
 		8A196B1C49507F3B8EAFD7FC /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
 		8A398E1B56F34E05126BAFBD /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
+		8A4B656BA8D0E707FDC3772C /* BiometricKycResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricKycResultDelegate.swift; path = Sources/SmileID/Classes/BiometricKYC/BiometricKycResultDelegate.swift; sourceTree = "<group>"; };
 		8A761F976500963587570159 /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
 		8A8BF9649EBEC6E9DF63768D /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyContainer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyContainer.swift; sourceTree = "<group>"; };
 		8AD393970990BAED6E11121D /* NavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationBar.swift; path = Sources/SmileID/Classes/Navigation/NavigationBar.swift; sourceTree = "<group>"; };
@@ -1462,15 +1509,18 @@
 		8CEBF43FF09AB693EB6E9947 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
 		8CF8261BCB2E7A12E1C92F35 /* SmileIDService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDService.swift; path = Sources/SmileID/Classes/Networking/SmileIDService.swift; sourceTree = "<group>"; };
 		8CFE7F396F0C2486A7CD2318 /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
+		8D076AC7EABF859B50983AC1 /* RectangleDectorFunnel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDectorFunnel.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDectorFunnel.swift; sourceTree = "<group>"; };
 		8D2B5F5862460D872303C709 /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		8D3F332278C45AB750EA05CB /* EnhancedKyc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedKyc.swift; path = Sources/SmileID/Classes/Networking/Models/EnhancedKyc.swift; sourceTree = "<group>"; };
 		8D6CF5BF27C223B9D88C2324 /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
+		8D6F2AACC7B5633D65F3C43C /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		8D707D4ECCE74EDB8B7AC5CF /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
 		8D80D13E419BBBC5FE8855D9 /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
 		8D923D77701F01331222DD7B /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		8DB2FC0B5A1F7A732B13F776 /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
 		8E34ABD7919E50E8ADB43859 /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
 		8E36E87AADBF98C282394B93 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
+		8E4119D363BCC420540C7750 /* Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = Sources/SmileID/Classes/Networking/Models/Authentication.swift; sourceTree = "<group>"; };
 		8E84230E91C3DA718A1E480C /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
 		8E93D1CD541B59039CC94578 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
 		8E9DA68E2F09A409CCE2873A /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
@@ -1479,12 +1529,14 @@
 		8F35CE5B1EA9244563697AB3 /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		8F5208E3D8DA8D54E8002DC6 /* ARViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ARViewController.swift; path = Sources/SmileID/Classes/SelfieCapture/View/ARViewController.swift; sourceTree = "<group>"; };
 		8F629F38735607F6D90414DC /* FaceGeometryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceGeometryModel.swift; path = Sources/SmileID/Classes/FaceDetector/FaceGeometryModel.swift; sourceTree = "<group>"; };
+		8F79721370C7B2353C8447ED /* CameraView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraView.swift; path = Sources/SmileID/Classes/SelfieCapture/View/CameraView.swift; sourceTree = "<group>"; };
 		8FA78D7DBD432F9364D6DA6A /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		8FB9AAAEB3EB7AC5ADDB653E /* FaceDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetector.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetector.swift; sourceTree = "<group>"; };
 		8FC2438E210A6B2CD7B89769 /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
 		8FF59574DED2FCBEB06D9814 /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
 		8FFCF334788E5D3E1AD86AE5 /* EpilogueFont.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EpilogueFont.swift; path = Sources/SmileID/Classes/Helpers/EpilogueFont.swift; sourceTree = "<group>"; };
 		901F2283C7B4B9F84F9C1C03 /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
+		902E486A9BF49DC7305E0C4A /* CameraError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraError.swift; path = Sources/SmileID/Classes/Camera/CameraError.swift; sourceTree = "<group>"; };
 		906B875AB7B9FA8A0E6387A2 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		90B7B986DE2DE0A53642AD6C /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
 		90C4EDC3B3E141C403F88942 /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
@@ -1509,8 +1561,12 @@
 		9263B0EDAFD41A401233D559 /* OrchestratedBiometricKycScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycScreen.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift; sourceTree = "<group>"; };
 		9265BDF0855C05BA2B9E6DDA /* OrchestratedBiometricKycScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycScreen.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift; sourceTree = "<group>"; };
 		92A2E78382DCDF41BAAE25F6 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
+		92D302C549E273A69B80C014 /* NavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationBar.swift; path = Sources/SmileID/Classes/Navigation/NavigationBar.swift; sourceTree = "<group>"; };
 		92F0E6F297274A58AD25CE66 /* DocumentCaptureViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift; sourceTree = "<group>"; };
+		9324B5C321B7ECD09482E9B6 /* SelfieCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureResultStore.swift; path = Sources/SmileID/Classes/SelfieCapture/ViewModel/SelfieCaptureResultStore.swift; sourceTree = "<group>"; };
+		9325CDEF1DD3EDD53E8C8CC2 /* SelfieViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieViewModel.swift; path = Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift; sourceTree = "<group>"; };
 		9339249BF5205ED69017A5B0 /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
+		9346CCA1D50B64C7E1B21322 /* JobStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobStatus.swift; path = Sources/SmileID/Classes/Networking/Models/JobStatus.swift; sourceTree = "<group>"; };
 		937F5FE3A8AE2920DDF44044 /* URLSessionPublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionPublisher.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionPublisher.swift; sourceTree = "<group>"; };
 		939F10A11E37773BC23AB692 /* FaceGeometryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceGeometryModel.swift; path = Sources/SmileID/Classes/FaceDetector/FaceGeometryModel.swift; sourceTree = "<group>"; };
 		93BAF06828E1DCE5397804CC /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
@@ -1524,6 +1580,7 @@
 		94B2C6113A9EE243DC1F84A8 /* InfiniteProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteProgressBar.swift; path = Sources/SmileID/Classes/SelfieCapture/View/InfiniteProgressBar.swift; sourceTree = "<group>"; };
 		94E261732DD7245CFDEBF926 /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyContainer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyContainer.swift; sourceTree = "<group>"; };
 		956C00461B52DBD40FAD9845 /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
+		957093C1EFEFE67437FB62DB /* EnhancedDocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		958D233D728FC1DC7DE52AAF /* InfiniteProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteProgressBar.swift; path = Sources/SmileID/Classes/SelfieCapture/View/InfiniteProgressBar.swift; sourceTree = "<group>"; };
 		9592D6D0070AF9408E1E0A66 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		95E786A18A1BD0B9CBBE703E /* SmileID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileID.swift; path = Sources/SmileID/Classes/SmileID.swift; sourceTree = "<group>"; };
@@ -1553,6 +1610,7 @@
 		99B7873D9AC4B94529A5391D /* FaceGeometryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceGeometryModel.swift; path = Sources/SmileID/Classes/FaceDetector/FaceGeometryModel.swift; sourceTree = "<group>"; };
 		99CF359BCA570A2B3450418A /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
 		99D42E4222FE39AA7CC7ECE7 /* ServiceRunnable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceRunnable.swift; path = Sources/SmileID/Classes/Networking/ServiceRunnable.swift; sourceTree = "<group>"; };
+		99DCE137A3CCF5583E7FCFF9 /* URLSessionRestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionRestServiceClient.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift; sourceTree = "<group>"; };
 		99E3582CF1B3E2BAFF35A02F /* JobStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobStatus.swift; path = Sources/SmileID/Classes/Networking/Models/JobStatus.swift; sourceTree = "<group>"; };
 		9A34C8DA4A73C97CEBFFF2F5 /* SmileID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileID.swift; path = Sources/SmileID/Classes/SmileID.swift; sourceTree = "<group>"; };
 		9A76A7C43BEE57669FAD8675 /* SmartSelfieResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieResultDelegate.swift; path = Sources/SmileID/Classes/SelfieCapture/SmartSelfieResultDelegate.swift; sourceTree = "<group>"; };
@@ -1599,8 +1657,10 @@
 		9FB9B6AA3B18439ABA4A3163 /* FaceGeometryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceGeometryModel.swift; path = Sources/SmileID/Classes/FaceDetector/FaceGeometryModel.swift; sourceTree = "<group>"; };
 		9FDA44884CFC9316A3C9A6CD /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		9FEDCBE22F2ABF7935AB538C /* ImageUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageUtils.swift; path = Sources/SmileID/Classes/Helpers/ImageUtils.swift; sourceTree = "<group>"; };
+		9FF58FED36068A8A8EAE274E /* SmileIDService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDService.swift; path = Sources/SmileID/Classes/Networking/SmileIDService.swift; sourceTree = "<group>"; };
 		9FFE00B53E1A473A5E303039 /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
 		A01A0913619B7C265D7DAA60 /* DocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
+		A0794E733AF10A0B6507EE12 /* InfiniteProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteProgressBar.swift; path = Sources/SmileID/Classes/SelfieCapture/View/InfiniteProgressBar.swift; sourceTree = "<group>"; };
 		A08ABC12DD04029442E89D70 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
 		A0DFA767C6053B8E531B0318 /* OrchestratedSelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedSelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/OrchestratedSelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		A0E70FA72943CD2D99BD4592 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
@@ -1611,6 +1671,7 @@
 		A11C57C457F4D95A23282D26 /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		A11CEC6D3CC65A95FD313CE2 /* Config.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Config.swift; path = Sources/SmileID/Classes/Networking/Models/Config.swift; sourceTree = "<group>"; };
 		A1248B6BEA999A754F18F97C /* DocumentCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureResultStore.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureResultStore.swift; sourceTree = "<group>"; };
+		A16C8B77484E4EE044DC81E9 /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
 		A1701BCC5D2B1E0191F08B57 /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyContainer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyContainer.swift; sourceTree = "<group>"; };
 		A1A09D8749216F043CAD0B67 /* RestartableTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestartableTimer.swift; path = Sources/SmileID/Classes/RestartableTimer.swift; sourceTree = "<group>"; };
 		A1B168F5DA1196E19F273B56 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
@@ -1628,6 +1689,7 @@
 		A37121E809567DFF4D629B78 /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
 		A378B97053E13D60555EA8F5 /* OrchestratedConsentScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedConsentScreen.swift; path = Sources/SmileID/Classes/Consent/OrchestratedConsentScreen.swift; sourceTree = "<group>"; };
 		A38B43C038753ACD0B3C6B63 /* Injected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injected.swift; path = Sources/SmileID/Classes/DependencyContainer/Injected.swift; sourceTree = "<group>"; };
+		A3AAE335A1066C7EA8DAF7CE /* DependencyResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyResolver.swift; sourceTree = "<group>"; };
 		A3C49BADA04535B3037549DA /* EnhancedDocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		A3D1F6AC13F1FD92568DA08A /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
 		A3F82EDB4338514CB3C74CDF /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
@@ -1639,6 +1701,7 @@
 		A4AEF5CDFF539BCA8E2BCB0D /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = Sources/SmileID/Classes/Helpers/Colors.swift; sourceTree = "<group>"; };
 		A4C8728B9DCC988BE4F141EE /* Injected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injected.swift; path = Sources/SmileID/Classes/DependencyContainer/Injected.swift; sourceTree = "<group>"; };
 		A4DE007B7F85813141F92273 /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
+		A53560F9812139E6F893C282 /* BVN.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BVN.swift; path = Sources/SmileID/Classes/Networking/Models/BVN.swift; sourceTree = "<group>"; };
 		A540FF0404E7884B827A2BD0 /* ImageExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageExtensions.swift; path = Sources/SmileID/Classes/Helpers/ImageExtensions.swift; sourceTree = "<group>"; };
 		A55D7D6C28EB307D207050DB /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		A576047696C017BBC5710B31 /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = Sources/SmileID/Classes/Helpers/Colors.swift; sourceTree = "<group>"; };
@@ -1650,6 +1713,7 @@
 		A6374EFCB84EC8F36FB8F383 /* Transformable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Transformable.swift; path = Sources/SmileID/Classes/RectangleDetector/Transformable.swift; sourceTree = "<group>"; };
 		A644096418B6CE501D2444E5 /* OrchestratedSelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedSelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/OrchestratedSelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		A648653C8686118507A00FAC /* TextDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextDetector.swift; path = Sources/SmileID/Classes/DocumentVerification/TextDetector/TextDetector.swift; sourceTree = "<group>"; };
+		A6719B24E9AA936133DFB007 /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
 		A6822DEDC41E3A65C7C8B6F3 /* FaceShape.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShape.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShape.swift; sourceTree = "<group>"; };
 		A69CE5D25C8AFD94CC5DF7D5 /* ServiceHeaderProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceHeaderProvider.swift; path = Sources/SmileID/Classes/Networking/ServiceHeaderProvider.swift; sourceTree = "<group>"; };
 		A6A23632A770BF5F62A7BF74 /* SmileIDLocalizableStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDLocalizableStrings.swift; path = Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift; sourceTree = "<group>"; };
@@ -1657,6 +1721,7 @@
 		A6BABDF4514EE91D6D3F9CDB /* Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = Sources/SmileID/Classes/Networking/Models/Authentication.swift; sourceTree = "<group>"; };
 		A6BD0BFCB949394AE7C8F94D /* ValidDocuments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ValidDocuments.swift; path = Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift; sourceTree = "<group>"; };
 		A6D2FD8CE67EF087122E772C /* EpilogueFont.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EpilogueFont.swift; path = Sources/SmileID/Classes/Helpers/EpilogueFont.swift; sourceTree = "<group>"; };
+		A7112C14F67DA4BAB342EDB1 /* HTTPHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPHeader.swift; path = Sources/SmileID/Classes/Networking/HTTPHeader.swift; sourceTree = "<group>"; };
 		A735E7E6CAAAC598B4E823E4 /* RestartableTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestartableTimer.swift; path = Sources/SmileID/Classes/RestartableTimer.swift; sourceTree = "<group>"; };
 		A75F9D8F12A89C546CD410D0 /* DocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		A769D4396D59CEE0ADE7C503 /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
@@ -1679,6 +1744,7 @@
 		A9137850B68FC4C2781F570C /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyContainer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyContainer.swift; sourceTree = "<group>"; };
 		A94BE226D1AB940E8AC28CDA /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		A9596B395F66D06D82A77199 /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
+		A972AF39AD9E43DE098D2E2F /* ImageExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageExtensions.swift; path = Sources/SmileID/Classes/Helpers/ImageExtensions.swift; sourceTree = "<group>"; };
 		A9823D395A7F2539DC58EB4A /* SelfieViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieViewModel.swift; path = Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift; sourceTree = "<group>"; };
 		A98E5B68A6A264B28E66D259 /* FaceGeometryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceGeometryModel.swift; path = Sources/SmileID/Classes/FaceDetector/FaceGeometryModel.swift; sourceTree = "<group>"; };
 		A9B8E096DC6C92E77C70EF93 /* SmartSelfieResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieResultDelegate.swift; path = Sources/SmileID/Classes/SelfieCapture/SmartSelfieResultDelegate.swift; sourceTree = "<group>"; };
@@ -1688,6 +1754,7 @@
 		A9FC713F6FE260DEA43B92DE /* DocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		AA073B3B6368A8B7FEA68524 /* OrchestratedDocumentVerificationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift; sourceTree = "<group>"; };
 		AA48FB23E02CBAB44C8C6A41 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
+		AA928B469A4F5374337E2527 /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
 		AA94BA34C57A40376609D1E5 /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		AA94DA584A8F3BDB03E3FDEF /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
 		AA9E3B0ACA2B79D1E3A769F5 /* OrchestratedDocumentVerificationScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift; sourceTree = "<group>"; };
@@ -1711,6 +1778,7 @@
 		AD033E1830E1FFE923D3E4E1 /* SmileID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileID.swift; path = Sources/SmileID/Classes/SmileID.swift; sourceTree = "<group>"; };
 		AD35B929FAACE3F81EAE3656 /* BiometricKycResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricKycResultDelegate.swift; path = Sources/SmileID/Classes/BiometricKYC/BiometricKycResultDelegate.swift; sourceTree = "<group>"; };
 		AD3BF5B8B883F9324EF668F4 /* EnhancedDocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
+		AD49A1979669D391434BC990 /* EpilogueFont.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EpilogueFont.swift; path = Sources/SmileID/Classes/Helpers/EpilogueFont.swift; sourceTree = "<group>"; };
 		AD5AEDE92EC6002C2AB61C25 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		AE28DF0AD16ABD9A630CD7EC /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
 		AE2DEE657D17EDD5D78B6CDC /* SmileIDLocalizableStrings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDLocalizableStrings.swift; path = Sources/SmileID/Classes/Helpers/SmileIDLocalizableStrings.swift; sourceTree = "<group>"; };
@@ -1752,12 +1820,14 @@
 		B32D2B9E24D93AA947330D2C /* FaceDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetector.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetector.swift; sourceTree = "<group>"; };
 		B34338B6CDDB43A662D5865F /* HTTPHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPHeader.swift; path = Sources/SmileID/Classes/Networking/HTTPHeader.swift; sourceTree = "<group>"; };
 		B35CF90CC52705221C2BD3AA /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
+		B37116A2193FD09C63FA79BD /* SmileButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileButton.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift; sourceTree = "<group>"; };
 		B3CC0753097D910CF8230629 /* ImageCaptureConfirmationDialog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageCaptureConfirmationDialog.swift; path = Sources/SmileID/Classes/Views/ImageCaptureConfirmationDialog.swift; sourceTree = "<group>"; };
 		B3EF5C146FCBDE95879F23B0 /* ImagePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImagePicker.swift; path = Sources/SmileID/Classes/DocumentVerification/View/ImagePicker.swift; sourceTree = "<group>"; };
 		B47814E0517978ACEA087B2E /* NavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationBar.swift; path = Sources/SmileID/Classes/Navigation/NavigationBar.swift; sourceTree = "<group>"; };
 		B4A3E21B24FF157749B635CF /* NetworkUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkUtil.swift; path = Sources/SmileID/Classes/Networking/NetworkUtil.swift; sourceTree = "<group>"; };
 		B512A3C9E08A3DB89DD4EC7A /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		B5414FE925E1B6AFD4F732CF /* ServiceHeaderProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceHeaderProvider.swift; path = Sources/SmileID/Classes/Networking/ServiceHeaderProvider.swift; sourceTree = "<group>"; };
+		B5617483BB26266BE9C8BC28 /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
 		B57B769890C22E9955A6BD3C /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		B58EC1EE8E7A64B13FDB77D7 /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		B59EE019A6F2FF577CDA7136 /* ServiceRunnable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceRunnable.swift; path = Sources/SmileID/Classes/Networking/ServiceRunnable.swift; sourceTree = "<group>"; };
@@ -1793,12 +1863,15 @@
 		B99710C1929E96CB98E3B459 /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		B9ADDAA25CB198251282E691 /* PrepUpload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrepUpload.swift; path = Sources/SmileID/Classes/Networking/Models/PrepUpload.swift; sourceTree = "<group>"; };
 		B9BF32DB8AA9C202D83BD73F /* ServiceRunnable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceRunnable.swift; path = Sources/SmileID/Classes/Networking/ServiceRunnable.swift; sourceTree = "<group>"; };
+		B9DC0780B8908157E94E6AC5 /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
 		B9EB8BE9C4C8B2FB2B53DD49 /* ImageUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageUtils.swift; path = Sources/SmileID/Classes/Helpers/ImageUtils.swift; sourceTree = "<group>"; };
 		BA012C232A0F657C75D15FAC /* CameraView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraView.swift; path = Sources/SmileID/Classes/SelfieCapture/View/CameraView.swift; sourceTree = "<group>"; };
 		BAA1323088FAF689979DC80C /* SelfieCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift; sourceTree = "<group>"; };
 		BADE7487553C708D3134419B /* SelfieViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieViewModel.swift; path = Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift; sourceTree = "<group>"; };
 		BB03D91FD7976AB7B8883C82 /* RadioGroupSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RadioGroupSelector.swift; path = Sources/SmileID/Classes/Views/RadioGroupSelector.swift; sourceTree = "<group>"; };
 		BB588292F8F70E27EF9D10E1 /* FaceShape.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShape.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShape.swift; sourceTree = "<group>"; };
+		BB6754612C1F5A7931772898 /* ServiceRunnable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceRunnable.swift; path = Sources/SmileID/Classes/Networking/ServiceRunnable.swift; sourceTree = "<group>"; };
+		BB7C55CAAC288E619AFD48B7 /* RectangleDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RectangleDetector.swift; path = Sources/SmileID/Classes/RectangleDetector/RectangleDetector.swift; sourceTree = "<group>"; };
 		BB8842CD03F6D2A5391F5142 /* JobStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobStatus.swift; path = Sources/SmileID/Classes/Networking/Models/JobStatus.swift; sourceTree = "<group>"; };
 		BBA5939C3FD4C25763C35B51 /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
 		BBB768FEAB4D7302D9BC5E1B /* ServiceHeaderProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceHeaderProvider.swift; path = Sources/SmileID/Classes/Networking/ServiceHeaderProvider.swift; sourceTree = "<group>"; };
@@ -1827,6 +1900,7 @@
 		BE274CF42D74D4D8B952627A /* BiometricKycResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricKycResultDelegate.swift; path = Sources/SmileID/Classes/BiometricKYC/BiometricKycResultDelegate.swift; sourceTree = "<group>"; };
 		BE44C54B7F674E5BB150048D /* InfiniteProgressBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteProgressBar.swift; path = Sources/SmileID/Classes/SelfieCapture/View/InfiniteProgressBar.swift; sourceTree = "<group>"; };
 		BE54056C1BB7253D90F15F45 /* Config.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Config.swift; path = Sources/SmileID/Classes/Networking/Models/Config.swift; sourceTree = "<group>"; };
+		BE7B9CB0FB27584F272064C7 /* APIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIError.swift; path = Sources/SmileID/Classes/Networking/APIError.swift; sourceTree = "<group>"; };
 		BE83DFF9ABF6EF6346ED0959 /* EnhancedDocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedDocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/EnhancedDocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		BE90030CBFA2A9910EE28A6F /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		BEC3C55801BF1472FC9F4B03 /* EnhancedKyc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedKyc.swift; path = Sources/SmileID/Classes/Networking/Models/EnhancedKyc.swift; sourceTree = "<group>"; };
@@ -1871,11 +1945,13 @@
 		C2E8127FB757914092F7B2C6 /* UploadRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UploadRequest.swift; path = Sources/SmileID/Classes/Networking/Models/UploadRequest.swift; sourceTree = "<group>"; };
 		C35A66A6E30D9B951E4E6A21 /* SmileButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileButton.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmileButton.swift; sourceTree = "<group>"; };
 		C36294842F7A9B515FC135BE /* BiometricKycResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BiometricKycResultDelegate.swift; path = Sources/SmileID/Classes/BiometricKYC/BiometricKycResultDelegate.swift; sourceTree = "<group>"; };
+		C3768E1DF4C52E461D79C44A /* SmartSelfieResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieResultDelegate.swift; path = Sources/SmileID/Classes/SelfieCapture/SmartSelfieResultDelegate.swift; sourceTree = "<group>"; };
 		C3876A6E24A584FD92FEB3AA /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
 		C3896F3641877718B65FB245 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		C3A752CE80BB5A875AE41C1A /* JobType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobType.swift; path = Sources/SmileID/Classes/Networking/Models/JobType.swift; sourceTree = "<group>"; };
 		C3E7E05C14939A9F7F0A046A /* FaceDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetector.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetector.swift; sourceTree = "<group>"; };
 		C3F67BBF186AC72E940A189E /* Transformable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Transformable.swift; path = Sources/SmileID/Classes/RectangleDetector/Transformable.swift; sourceTree = "<group>"; };
+		C3FBA7B8AF49080BDFF2FAB1 /* Theme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Theme.swift; path = Sources/SmileID/Classes/Helpers/Theme.swift; sourceTree = "<group>"; };
 		C4113666E6F4DFA9281024CB /* FaceDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetector.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetector.swift; sourceTree = "<group>"; };
 		C446F5C8D80F7BEA6B66AB14 /* RestServiceClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestServiceClient.swift; path = Sources/SmileID/Classes/Networking/RestServiceClient.swift; sourceTree = "<group>"; };
 		C474D8D49EC07FBC6CAEEB3E /* DocumentCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureResultStore.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureResultStore.swift; sourceTree = "<group>"; };
@@ -1902,6 +1978,7 @@
 		C71C59A5A81056AB935E1D30 /* Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = Sources/SmileID/Classes/Networking/Models/Authentication.swift; sourceTree = "<group>"; };
 		C724124B1DCB0F9E78C0AB65 /* FaceGeometryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceGeometryModel.swift; path = Sources/SmileID/Classes/FaceDetector/FaceGeometryModel.swift; sourceTree = "<group>"; };
 		C780F00487A96229FD603F33 /* HTTPQueryParameters.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPQueryParameters.swift; path = Sources/SmileID/Classes/Networking/HTTPQueryParameters.swift; sourceTree = "<group>"; };
+		C7CD5A394AE2F4648C8A89F9 /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		C83189DFEAC3B435E4080F80 /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
 		C8321FBD51629E3BDDFD46D2 /* SmartSelfieResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieResultDelegate.swift; path = Sources/SmileID/Classes/SelfieCapture/SmartSelfieResultDelegate.swift; sourceTree = "<group>"; };
 		C86D21A89CCDD7BC9DFE3328 /* DependencyResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyResolver.swift; sourceTree = "<group>"; };
@@ -1977,6 +2054,7 @@
 		CFBE4F037D79156EF42E9A8F /* Transformable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Transformable.swift; path = Sources/SmileID/Classes/RectangleDetector/Transformable.swift; sourceTree = "<group>"; };
 		CFC58935D5C6A25447452C33 /* FontType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FontType.swift; path = Sources/SmileID/Classes/Helpers/FontType.swift; sourceTree = "<group>"; };
 		D0010F6189D152B5BEDD423C /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
+		D0043CD96B3904B3CE36F943 /* DocumentCaptureResultStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureResultStore.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureResultStore.swift; sourceTree = "<group>"; };
 		D039E11A363E7B0B9ED8D9F6 /* HTTPHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HTTPHeader.swift; path = Sources/SmileID/Classes/Networking/HTTPHeader.swift; sourceTree = "<group>"; };
 		D043221A2BA54409F5817A54 /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
 		D04ECE617C77B5384C9876AF /* UploadRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UploadRequest.swift; path = Sources/SmileID/Classes/Networking/Models/UploadRequest.swift; sourceTree = "<group>"; };
@@ -1990,6 +2068,7 @@
 		D0DDFD76BC19F13FA7D288C8 /* FaceShapedProgressIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShapedProgressIndicator.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShapedProgressIndicator.swift; sourceTree = "<group>"; };
 		D0F88A820EC334AF7513B0B9 /* ActivityIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ActivityIndicator.swift; path = Sources/SmileID/Classes/Views/ActivityIndicator.swift; sourceTree = "<group>"; };
 		D12FAFDE1ABF22A2F46BFF8F /* LocalizedStringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedStringExtensions.swift; path = Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift; sourceTree = "<group>"; };
+		D1367CC19F810B6CF7FB9D90 /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
 		D15177ACC9ABA69902BDFA75 /* ValidDocuments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ValidDocuments.swift; path = Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift; sourceTree = "<group>"; };
 		D1747DEB99F9722EB0B5FF38 /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		D1800BC2E3E966C4D80FC48F /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
@@ -2037,6 +2116,7 @@
 		D56C58068F056B57966CED5F /* PartnerParams.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PartnerParams.swift; path = Sources/SmileID/Classes/Networking/Models/PartnerParams.swift; sourceTree = "<group>"; };
 		D5D4742FC04B196406EC3AC8 /* URLSessionPublisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLSessionPublisher.swift; path = Sources/SmileID/Classes/Networking/URLSession/URLSessionPublisher.swift; sourceTree = "<group>"; };
 		D5E16B1EE8EB57297A8D1079 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
+		D60CC438E25A1C5E650930BC /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		D63E42EAEBDB21D89AFAB1B7 /* LocalizedStringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedStringExtensions.swift; path = Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift; sourceTree = "<group>"; };
 		D655856723BB57B409B741DE /* UploadRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UploadRequest.swift; path = Sources/SmileID/Classes/Networking/Models/UploadRequest.swift; sourceTree = "<group>"; };
 		D655D7562F7232E19FAA047C /* SelfieCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfieCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
@@ -2124,6 +2204,7 @@
 		E02CABAD6CCD2B4FCDE86AB2 /* CameraManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraManager.swift; path = Sources/SmileID/Classes/Camera/CameraManager.swift; sourceTree = "<group>"; };
 		E06CD81A087D74E40B505B1D /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		E08511D8BE24AA1E75FACC2A /* Transformable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Transformable.swift; path = Sources/SmileID/Classes/RectangleDetector/Transformable.swift; sourceTree = "<group>"; };
+		E09512BAE4AA0BEA998BE625 /* OrchestratedBiometricKycViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycViewModel.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift; sourceTree = "<group>"; };
 		E0EE75A33CD21841FDF813D2 /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
 		E0F5F228FD9F9E0E11C2F7BD /* CameraError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraError.swift; path = Sources/SmileID/Classes/Camera/CameraError.swift; sourceTree = "<group>"; };
 		E0F84DFD10D529CD7DD143A6 /* SearchableDropdownSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchableDropdownSelector.swift; path = Sources/SmileID/Classes/Views/SearchableDropdownSelector.swift; sourceTree = "<group>"; };
@@ -2150,12 +2231,14 @@
 		E40CA7BB120520D06A6FB810 /* ValidDocuments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ValidDocuments.swift; path = Sources/SmileID/Classes/Networking/Models/ValidDocuments.swift; sourceTree = "<group>"; };
 		E46831F352CB536245D23EF2 /* OrchestratedBiometricKycScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycScreen.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift; sourceTree = "<group>"; };
 		E479F8EF53FFFC034E190BE1 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
+		E4C940B8AB5449CF8BFA3C27 /* OrchestratedBiometricKycScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycScreen.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift; sourceTree = "<group>"; };
 		E4D888A576C4C7EDC468AA03 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
 		E4FDDFE72B18FFABE739908D /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		E59D69C07176670BBBB3AC5E /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = Sources/SmileID/Classes/Helpers/Colors.swift; sourceTree = "<group>"; };
 		E5AF6D7264B1CD47C13BEB5C /* SmileIDResourcesHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmileIDResourcesHelper.swift; path = Sources/SmileID/Classes/Helpers/SmileIDResourcesHelper.swift; sourceTree = "<group>"; };
 		E60B3B098C0719D8FA73FFCD /* Injected.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injected.swift; path = Sources/SmileID/Classes/DependencyContainer/Injected.swift; sourceTree = "<group>"; };
 		E620453424AA558CD701F494 /* APIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIError.swift; path = Sources/SmileID/Classes/Networking/APIError.swift; sourceTree = "<group>"; };
+		E65F040378440599FF776A20 /* UploadRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UploadRequest.swift; path = Sources/SmileID/Classes/Networking/Models/UploadRequest.swift; sourceTree = "<group>"; };
 		E664E5FF6276AFE87B2139D4 /* EnhancedKyc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedKyc.swift; path = Sources/SmileID/Classes/Networking/Models/EnhancedKyc.swift; sourceTree = "<group>"; };
 		E7139F22869412C7A2FE7CBD /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		E7382D4B9161DF7DE4E69407 /* RestRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestRequest.swift; path = Sources/SmileID/Classes/Networking/RestRequest.swift; sourceTree = "<group>"; };
@@ -2177,6 +2260,7 @@
 		EA3949FBB62C63F76600F3CC /* APIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIError.swift; path = Sources/SmileID/Classes/Networking/APIError.swift; sourceTree = "<group>"; };
 		EA3DA94E54D879CB53CD8637 /* NavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationBar.swift; path = Sources/SmileID/Classes/Navigation/NavigationBar.swift; sourceTree = "<group>"; };
 		EA52BE0DBFC899AC27CA6D13 /* StringConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringConstants.swift; path = Sources/SmileID/Classes/Helpers/StringConstants.swift; sourceTree = "<group>"; };
+		EA570C41F4DDAA7D98C99FB0 /* ImagePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImagePicker.swift; path = Sources/SmileID/Classes/DocumentVerification/View/ImagePicker.swift; sourceTree = "<group>"; };
 		EA5C8A07F9A84159E9104269 /* DependencyRegisterer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyRegisterer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyRegisterer.swift; sourceTree = "<group>"; };
 		EA5CC379AC8DFD4A72EEBDEF /* NavigationHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationHelper.swift; path = Sources/SmileID/Classes/Helpers/NavigationHelper.swift; sourceTree = "<group>"; };
 		EA6674122677B6C129B483B8 /* FaceShapedProgressIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShapedProgressIndicator.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShapedProgressIndicator.swift; sourceTree = "<group>"; };
@@ -2218,6 +2302,7 @@
 		EF783A0C9218B698B9D5E080 /* CaptureButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CaptureButton.swift; path = Sources/SmileID/Classes/DocumentVerification/View/CaptureButton.swift; sourceTree = "<group>"; };
 		EF8336C98B7000799D816C85 /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		EFC86E531B114EA61D10899A /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
+		EFEB6CD1096F226DD2BAFC0D /* FaceShapedProgressIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceShapedProgressIndicator.swift; path = Sources/SmileID/Classes/SelfieCapture/View/FaceShapedProgressIndicator.swift; sourceTree = "<group>"; };
 		EFEDC13EE319D2E48C71F808 /* DependencyRegisterer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyRegisterer.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyRegisterer.swift; sourceTree = "<group>"; };
 		EFEF84D5443EB7279C09EB32 /* OrchestratedBiometricKycViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycViewModel.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift; sourceTree = "<group>"; };
 		EFF73A0EB85A687B5D2EAD40 /* ImagePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImagePicker.swift; path = Sources/SmileID/Classes/DocumentVerification/View/ImagePicker.swift; sourceTree = "<group>"; };
@@ -2248,6 +2333,7 @@
 		F2E5B53045379C7029EF8AE4 /* OrchestratedBiometricKycViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedBiometricKycViewModel.swift; path = Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift; sourceTree = "<group>"; };
 		F353FC20EC6CC065BD0605CB /* JobType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobType.swift; path = Sources/SmileID/Classes/Networking/Models/JobType.swift; sourceTree = "<group>"; };
 		F3734763901338C24BA5D7E0 /* NavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NavigationBar.swift; path = Sources/SmileID/Classes/Navigation/NavigationBar.swift; sourceTree = "<group>"; };
+		F38EFB0C06B7F1ECFDB57A29 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
 		F3A0C7C342370777A1EA7C46 /* DocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		F3AB7066DBD4DCF9E68C4DB2 /* PrepUpload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrepUpload.swift; path = Sources/SmileID/Classes/Networking/Models/PrepUpload.swift; sourceTree = "<group>"; };
 		F3EA3211478374B4D24A0114 /* LocalizedStringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedStringExtensions.swift; path = Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift; sourceTree = "<group>"; };
@@ -2273,6 +2359,7 @@
 		F67F80CE93E3F0478587E8E3 /* OrchestratedDocumentVerificationScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrchestratedDocumentVerificationScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift; sourceTree = "<group>"; };
 		F6B198769D9FC3183A6A2E3E /* APIError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIError.swift; path = Sources/SmileID/Classes/Networking/APIError.swift; sourceTree = "<group>"; };
 		F6BDFF7861280292E950E1FF /* FaceDetectionState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceDetectionState.swift; path = Sources/SmileID/Classes/FaceDetector/FaceDetectionState.swift; sourceTree = "<group>"; };
+		F6CCB90E04B61E2F9712D55A /* DocumentCaptureViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureViewModel.swift; path = Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift; sourceTree = "<group>"; };
 		F6D9A36CBBFF7271B9841024 /* RestartableTimer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RestartableTimer.swift; path = Sources/SmileID/Classes/RestartableTimer.swift; sourceTree = "<group>"; };
 		F729C23503840B6C762B9114 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
 		F75D88AE78D6084933EDB15B /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
@@ -2297,6 +2384,7 @@
 		FAA7A0105EF09424E76844F1 /* JobType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobType.swift; path = Sources/SmileID/Classes/Networking/Models/JobType.swift; sourceTree = "<group>"; };
 		FABAABA674BD389F5DC41A35 /* ImagePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImagePicker.swift; path = Sources/SmileID/Classes/DocumentVerification/View/ImagePicker.swift; sourceTree = "<group>"; };
 		FAF97B38BADFA3A5F1C09F52 /* SmartSelfieResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieResultDelegate.swift; path = Sources/SmileID/Classes/SelfieCapture/SmartSelfieResultDelegate.swift; sourceTree = "<group>"; };
+		FB2057840F67E55D1CB5A304 /* JobSubmittable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JobSubmittable.swift; path = Sources/SmileID/Classes/Views/JobSubmittable.swift; sourceTree = "<group>"; };
 		FB2AC8D4EF8229E550A09D46 /* DependencyAutoResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DependencyAutoResolver.swift; path = Sources/SmileID/Classes/DependencyContainer/DependencyAutoResolver.swift; sourceTree = "<group>"; };
 		FB5A0678A713A10C31C28E08 /* DocumentCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift; sourceTree = "<group>"; };
 		FB6E8C30F508C2A070C833A1 /* EnvironmentValues.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnvironmentValues.swift; path = Sources/SmileID/Classes/Helpers/EnvironmentValues.swift; sourceTree = "<group>"; };
@@ -2309,6 +2397,7 @@
 		FC6C25666D30B17BD0F9E772 /* SmartSelfieInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartSelfieInstructionsScreen.swift; path = Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift; sourceTree = "<group>"; };
 		FCA4465DDFD1A3454BBE3FE5 /* Util.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Util.swift; path = Sources/SmileID/Classes/Util.swift; sourceTree = "<group>"; };
 		FCAEC6C8BBA47851A9A17706 /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Colors.swift; path = Sources/SmileID/Classes/Helpers/Colors.swift; sourceTree = "<group>"; };
+		FD0120EBC5E6063B54D10270 /* Transformable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Transformable.swift; path = Sources/SmileID/Classes/RectangleDetector/Transformable.swift; sourceTree = "<group>"; };
 		FD33B4BC55346876590119F1 /* DocumentVerificationResultDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentVerificationResultDelegate.swift; path = Sources/SmileID/Classes/DocumentVerification/DocumentVerificationResultDelegate.swift; sourceTree = "<group>"; };
 		FD4A6D69CC6F29B15095D09E /* Authentication.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authentication.swift; path = Sources/SmileID/Classes/Networking/Models/Authentication.swift; sourceTree = "<group>"; };
 		FD5986974E324394E270F53D /* LocalStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalStorage.swift; path = Sources/SmileID/Classes/Helpers/LocalStorage.swift; sourceTree = "<group>"; };
@@ -4341,6 +4430,95 @@
 				ABB9063DA4A537DECB635E8D /* ProcessingScreen.swift */,
 				3C64CF7FEFBFB57DB0241A22 /* RadioGroupSelector.swift */,
 				D71A5287085B2F124BD70276 /* SearchableDropdownSelector.swift */,
+				8A4B656BA8D0E707FDC3772C /* BiometricKycResultDelegate.swift */,
+				E4C940B8AB5449CF8BFA3C27 /* OrchestratedBiometricKycScreen.swift */,
+				E09512BAE4AA0BEA998BE625 /* OrchestratedBiometricKycViewModel.swift */,
+				902E486A9BF49DC7305E0C4A /* CameraError.swift */,
+				A6719B24E9AA936133DFB007 /* CameraManager.swift */,
+				B9DC0780B8908157E94E6AC5 /* CameraViewController.swift */,
+				3A621FC908F6EBC822569646 /* OrchestratedConsentScreen.swift */,
+				D1367CC19F810B6CF7FB9D90 /* DependencyAutoResolver.swift */,
+				02DC89BA02FB9EF5FD348368 /* DependencyContainer.swift */,
+				01EA8478FB5FFB2EF71D2BFB /* DependencyRegisterer.swift */,
+				A3AAE335A1066C7EA8DAF7CE /* DependencyResolver.swift */,
+				869313094012C40C847A8DA7 /* Injected.swift */,
+				48ACD7239CE3ADD1FC0CA3CF /* DocumentVerificationResultDelegate.swift */,
+				957093C1EFEFE67437FB62DB /* EnhancedDocumentVerificationResultDelegate.swift */,
+				D0043CD96B3904B3CE36F943 /* DocumentCaptureResultStore.swift */,
+				F6CCB90E04B61E2F9712D55A /* DocumentCaptureViewModel.swift */,
+				0089D278C1976B05515DD5AE /* OrchestratedDocumentVerificationViewModel.swift */,
+				14D27A10B2FEDA57B884CE2C /* TextDetector.swift */,
+				1225F850C1DE8F8C0E163F31 /* CaptureButton.swift */,
+				2DBABC0AFF9FE6BCFCC85EFF /* DocumentCaptureInstructionsScreen.swift */,
+				2057FBF6B6724BE33B6CC727 /* DocumentCaptureScreen.swift */,
+				F38EFB0C06B7F1ECFDB57A29 /* DocumentShapedBoundingBox.swift */,
+				EA570C41F4DDAA7D98C99FB0 /* ImagePicker.swift */,
+				3BA45274F4EFFAC65DD546FD /* OrchestratedDocumentVerificationScreen.swift */,
+				06105CBE10AACF8136C7E31A /* FaceDetectionState.swift */,
+				0EE1267131888D72E597C057 /* FaceDetector.swift */,
+				636B3CEE3F995092B1812019 /* FaceGeometryModel.swift */,
+				02CBEC87BED324042C21F876 /* Colors.swift */,
+				AA928B469A4F5374337E2527 /* EnvironmentValues.swift */,
+				AD49A1979669D391434BC990 /* EpilogueFont.swift */,
+				06F0A94C924BCCB3DE9CAE81 /* FontType.swift */,
+				A972AF39AD9E43DE098D2E2F /* ImageExtensions.swift */,
+				607EC249441CCB39F5C0AA59 /* ImageUtils.swift */,
+				6D372CD4133F27A2357FC62C /* LocalStorage.swift */,
+				580AFDE099C51F7C1B7E8410 /* LocalizedStringExtensions.swift */,
+				8D6F2AACC7B5633D65F3C43C /* NavigationHelper.swift */,
+				39E248E4551E42264204500B /* SmileIDLocalizableStrings.swift */,
+				036936D802EB58EA561358DE /* SmileIDResourcesHelper.swift */,
+				5CA2F1EF4B61DFC0A2C4132B /* StringConstants.swift */,
+				C3FBA7B8AF49080BDFF2FAB1 /* Theme.swift */,
+				92D302C549E273A69B80C014 /* NavigationBar.swift */,
+				BE7B9CB0FB27584F272064C7 /* APIError.swift */,
+				A7112C14F67DA4BAB342EDB1 /* HTTPHeader.swift */,
+				05EC84FF8A48C56E6B35CC82 /* HTTPQueryParameters.swift */,
+				8E4119D363BCC420540C7750 /* Authentication.swift */,
+				A53560F9812139E6F893C282 /* BVN.swift */,
+				889728410F75549D1952ADE4 /* Config.swift */,
+				4A82B6D757B610513C291388 /* EnhancedKyc.swift */,
+				9346CCA1D50B64C7E1B21322 /* JobStatus.swift */,
+				6C260279B85AB5E9363A08A3 /* JobType.swift */,
+				C7CD5A394AE2F4648C8A89F9 /* PartnerParams.swift */,
+				4D758EEF46F8083F17E89809 /* PrepUpload.swift */,
+				A16C8B77484E4EE044DC81E9 /* Services.swift */,
+				E65F040378440599FF776A20 /* UploadRequest.swift */,
+				68D264A99B640D834AAB0C93 /* ValidDocuments.swift */,
+				153AB9A6C99A275245425516 /* NetworkUtil.swift */,
+				035C45B5DDA568CA2F50D7C1 /* RestRequest.swift */,
+				7C7A459BDE41CD5A574427BF /* RestServiceClient.swift */,
+				7AF7A52C810A3E90396B2C7F /* ServiceHeaderProvider.swift */,
+				BB6754612C1F5A7931772898 /* ServiceRunnable.swift */,
+				9FF58FED36068A8A8EAE274E /* SmileIDService.swift */,
+				12CB54CB048501D9BF4406CF /* URLSessionPublisher.swift */,
+				99DCE137A3CCF5583E7FCFF9 /* URLSessionRestServiceClient.swift */,
+				57232D62231C6B5B4BCB1428 /* Quadrilateral.swift */,
+				8D076AC7EABF859B50983AC1 /* RectangleDectorFunnel.swift */,
+				BB7C55CAAC288E619AFD48B7 /* RectangleDetector.swift */,
+				FD0120EBC5E6063B54D10270 /* Transformable.swift */,
+				0FD976FF184A1BC7FF56197C /* RestartableTimer.swift */,
+				9325CDEF1DD3EDD53E8C8CC2 /* SelfieViewModel.swift */,
+				C3768E1DF4C52E461D79C44A /* SmartSelfieResultDelegate.swift */,
+				3175212207C6A15C5D10C555 /* ARViewController.swift */,
+				8F79721370C7B2353C8447ED /* CameraView.swift */,
+				4300C8643D4A5971B5294941 /* FaceShape.swift */,
+				EFEB6CD1096F226DD2BAFC0D /* FaceShapedProgressIndicator.swift */,
+				A0794E733AF10A0B6507EE12 /* InfiniteProgressBar.swift */,
+				4E3D4E1F52B5907FF0FEC3FF /* OrchestratedSelfieCaptureScreen.swift */,
+				886BD74D81925A487A6D3F09 /* SelfieCaptureScreen.swift */,
+				7AAF579248140D2504A4EAB8 /* SmartSelfieInstructionsScreen.swift */,
+				B37116A2193FD09C63FA79BD /* SmileButton.swift */,
+				9324B5C321B7ECD09482E9B6 /* SelfieCaptureResultStore.swift */,
+				2FAFBA133860FEB80AAE2AB5 /* SmileID.swift */,
+				D60CC438E25A1C5E650930BC /* Util.swift */,
+				130CB83343BE63F407EE9721 /* ActivityIndicator.swift */,
+				03FF7E77C168337E221826F5 /* AspectRatioRoundedRectangle.swift */,
+				4DA4F7C3D326E512B2E492A6 /* ImageCaptureConfirmationDialog.swift */,
+				FB2057840F67E55D1CB5A304 /* JobSubmittable.swift */,
+				5DFC0FF5D22CB7A28E7BD03E /* ProcessingScreen.swift */,
+				470BF95962F91E56C6630123 /* RadioGroupSelector.swift */,
+				B5617483BB26266BE9C8BC28 /* SearchableDropdownSelector.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -4879,95 +5057,95 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BD9578010F44750875A3D838 /* BiometricKycResultDelegate.swift in Sources */,
-				8CBF48B7A22C35C641D2CCC9 /* OrchestratedBiometricKycScreen.swift in Sources */,
-				3C5E72AE30FAF0D55C8642C6 /* OrchestratedBiometricKycViewModel.swift in Sources */,
-				A0EEC8E7A0452FC9350A4B25 /* CameraError.swift in Sources */,
-				BBEDD73CAC411DDF62E94CE2 /* CameraManager.swift in Sources */,
-				748A4C0F9555214B5486C03B /* CameraViewController.swift in Sources */,
-				46D53B8485917F6EBFE99FCE /* OrchestratedConsentScreen.swift in Sources */,
-				1DA70AAE250F9D665DE4F6FF /* DependencyAutoResolver.swift in Sources */,
-				61D1F65FC036570FCC995860 /* DependencyContainer.swift in Sources */,
-				2AA8C1CB2CF079053C6D2E24 /* DependencyRegisterer.swift in Sources */,
-				CC8DE04204943D2BD0516C42 /* DependencyResolver.swift in Sources */,
-				1DA22148C9D4B6B268DD8665 /* Injected.swift in Sources */,
-				3C881D590D238B6AED8384DD /* DocumentVerificationResultDelegate.swift in Sources */,
-				74E2E88ADD54C15BD5A98A8F /* EnhancedDocumentVerificationResultDelegate.swift in Sources */,
-				AC43717BCEFB955ECA13C89E /* DocumentCaptureResultStore.swift in Sources */,
-				83CCFE7727286C45F36F2757 /* DocumentCaptureViewModel.swift in Sources */,
-				172A560DB5500F5442B6AC36 /* OrchestratedDocumentVerificationViewModel.swift in Sources */,
-				6019D5F3A8012D0EA3ECF953 /* TextDetector.swift in Sources */,
-				46BB6EA60FBE616F7B08CA45 /* CaptureButton.swift in Sources */,
-				94736EA5E276CE65C60EF030 /* DocumentCaptureInstructionsScreen.swift in Sources */,
-				123B3DC333A8D52F6E27704E /* DocumentCaptureScreen.swift in Sources */,
-				E50427D6A894B17F09871009 /* DocumentShapedBoundingBox.swift in Sources */,
-				D966A21DEA4D17FCD21814C3 /* ImagePicker.swift in Sources */,
-				AD432228BD0C4AB540D7B735 /* OrchestratedDocumentVerificationScreen.swift in Sources */,
-				618053D1765363D9ABFF1711 /* FaceDetectionState.swift in Sources */,
-				D6CD17F517E96D13201A2A94 /* FaceDetector.swift in Sources */,
-				88BFDF5D8874A60D4123D42A /* FaceGeometryModel.swift in Sources */,
-				AB5E9DD40028ECA61571EA0F /* Colors.swift in Sources */,
-				B3A01AC17606C21127DB1673 /* EnvironmentValues.swift in Sources */,
-				80A01CABC7BDF7224482D7B0 /* EpilogueFont.swift in Sources */,
-				16ED9816E06FDB4B360E4A39 /* FontType.swift in Sources */,
-				59A868ABE03FB7FEF706856D /* ImageExtensions.swift in Sources */,
-				59AFDB04C6212B86C09A3962 /* ImageUtils.swift in Sources */,
-				509CEFA30178BBB779554742 /* LocalStorage.swift in Sources */,
-				AEF8E4CE5751985EDB8F9F0A /* LocalizedStringExtensions.swift in Sources */,
-				874C9FCB67AB0BF3E9A33584 /* NavigationHelper.swift in Sources */,
-				7B5CD7D5103C6572CFA33601 /* SmileIDLocalizableStrings.swift in Sources */,
-				2419A4DF8068417F49E202A8 /* SmileIDResourcesHelper.swift in Sources */,
-				23F01494077D7AA4C58ADCBA /* StringConstants.swift in Sources */,
-				6DBA0DEBE0995D29AE830319 /* Theme.swift in Sources */,
-				1D092C3F41774E9B37CDE7B8 /* NavigationBar.swift in Sources */,
-				F4EA8929FC11E6292BEE2C4A /* APIError.swift in Sources */,
-				38AAC5F02FB8F8D9FA6DF12B /* HTTPHeader.swift in Sources */,
-				9C9FCA412A6B4C0701FDE75B /* HTTPQueryParameters.swift in Sources */,
-				E2131AA8D2B55F386FB20454 /* Authentication.swift in Sources */,
-				CCBFCF7F749AAF0B79FBF201 /* BVN.swift in Sources */,
-				8501D0A3F97A035129CE6A75 /* Config.swift in Sources */,
-				7B29DD7AB25B378C01700967 /* EnhancedKyc.swift in Sources */,
-				856B29086F3CD9A14F5610F1 /* JobStatus.swift in Sources */,
-				CE7151698E23BF7B1A9E256E /* JobType.swift in Sources */,
-				B2CD2585646DA796ED6133D3 /* PartnerParams.swift in Sources */,
-				DE53A14AED49AAF7B93FA7C3 /* PrepUpload.swift in Sources */,
-				B3949CCD064A7DD333C14651 /* Services.swift in Sources */,
-				2D41D5123A089EB24DE378A2 /* UploadRequest.swift in Sources */,
-				A1DA37A00D7D7DA82C453680 /* ValidDocuments.swift in Sources */,
-				BBCF657AB79210E01D99424E /* NetworkUtil.swift in Sources */,
-				72227A22EDB462FDC2944CB6 /* RestRequest.swift in Sources */,
-				259688E5A8EF0D8D0A41E61B /* RestServiceClient.swift in Sources */,
-				27FA3BE66A5FEA4924D8141B /* ServiceHeaderProvider.swift in Sources */,
-				40521D42D77DEDA0538ACFDF /* ServiceRunnable.swift in Sources */,
-				6E134DB5AD7C7F2C62FBB8B4 /* SmileIDService.swift in Sources */,
-				BFFC5B763C1DEC0BE6C618BC /* URLSessionPublisher.swift in Sources */,
-				987134E01BCEE3EB1C6545BB /* URLSessionRestServiceClient.swift in Sources */,
-				9C55DD6AB2087607754F1BFA /* Quadrilateral.swift in Sources */,
-				BD11CACEF204803DB6678B59 /* RectangleDectorFunnel.swift in Sources */,
-				95CCD3FE57BABA6B8413D8DB /* RectangleDetector.swift in Sources */,
-				23EBECB61E1EF26FC6491879 /* Transformable.swift in Sources */,
-				E4C7B8E310DCA97C0812BF70 /* RestartableTimer.swift in Sources */,
-				EE1EC028E58C7EEE2B4B5BA4 /* SelfieViewModel.swift in Sources */,
-				F8CCFF821576C48613F12E58 /* SmartSelfieResultDelegate.swift in Sources */,
-				5DD5111145DF6870429924CA /* ARViewController.swift in Sources */,
-				69BDD31220AE6E589DF6EC13 /* CameraView.swift in Sources */,
-				15C9C51CD05FB5B905F0A512 /* FaceShape.swift in Sources */,
-				1ED186D9CDD4A99AD6E59014 /* FaceShapedProgressIndicator.swift in Sources */,
-				0594E4C7825C7B2347CBD1CD /* InfiniteProgressBar.swift in Sources */,
-				48C8303F0E843B429D1B49C8 /* OrchestratedSelfieCaptureScreen.swift in Sources */,
-				40FD1945E1C1093E102EF406 /* SelfieCaptureScreen.swift in Sources */,
-				413584A0DB20B48D08B6B934 /* SmartSelfieInstructionsScreen.swift in Sources */,
-				0FCA4686C785CCF42F890069 /* SmileButton.swift in Sources */,
-				E69555499ACD807D37B01A12 /* SelfieCaptureResultStore.swift in Sources */,
-				D2C46F59B04BA3EC08767806 /* SmileID.swift in Sources */,
-				68BAA62E18112F59BC922D49 /* Util.swift in Sources */,
-				90908F49CFCC67F914824334 /* ActivityIndicator.swift in Sources */,
-				EFC158A4AD15EB2F4494850A /* AspectRatioRoundedRectangle.swift in Sources */,
-				7D704DEFE7A947EE5DAB6F08 /* ImageCaptureConfirmationDialog.swift in Sources */,
-				F5675F01A5EC1B199E78B87F /* JobSubmittable.swift in Sources */,
-				76015540BF576B2BB208A747 /* ProcessingScreen.swift in Sources */,
-				A6BD79A002BB2AE7532BFA49 /* RadioGroupSelector.swift in Sources */,
-				17110A590176503EFB7C49FF /* SearchableDropdownSelector.swift in Sources */,
+				FA2AFC322562FBB823E8E62A /* BiometricKycResultDelegate.swift in Sources */,
+				F90AEBF81A8CBF60DCD90995 /* OrchestratedBiometricKycScreen.swift in Sources */,
+				AF1F3C9C81F9926233EDBC80 /* OrchestratedBiometricKycViewModel.swift in Sources */,
+				C881AF5784DF77B819467F4B /* CameraError.swift in Sources */,
+				891B7653B1CA059C3AAE6101 /* CameraManager.swift in Sources */,
+				D8BAFAC40B0D6DA2793505D8 /* CameraViewController.swift in Sources */,
+				C06439FCCCA8FAEDA9F940DD /* OrchestratedConsentScreen.swift in Sources */,
+				015D86BBD180C7E8CC4F6CF2 /* DependencyAutoResolver.swift in Sources */,
+				E987E111B6E733211C05596F /* DependencyContainer.swift in Sources */,
+				B811D5DFCD7A8F98AE1F240F /* DependencyRegisterer.swift in Sources */,
+				272B51EE49D39C4AB65AB809 /* DependencyResolver.swift in Sources */,
+				40A0EDB939860E6E3414532C /* Injected.swift in Sources */,
+				684BD973F6E6FF0359B8B1AD /* DocumentVerificationResultDelegate.swift in Sources */,
+				E172A15938AE33FFFE72342C /* EnhancedDocumentVerificationResultDelegate.swift in Sources */,
+				F94A8143B70F0D7A207A2E5D /* DocumentCaptureResultStore.swift in Sources */,
+				773B1046DC05E6FB1B428BB1 /* DocumentCaptureViewModel.swift in Sources */,
+				7630BEA6AA54E19D0064F2E2 /* OrchestratedDocumentVerificationViewModel.swift in Sources */,
+				3DACEB2D827FA46A2155B856 /* TextDetector.swift in Sources */,
+				499A1C6B61680E0E7D5BE123 /* CaptureButton.swift in Sources */,
+				99B34F1FBAAA18AC5B7344D4 /* DocumentCaptureInstructionsScreen.swift in Sources */,
+				9FA3DD0D193EDE05D87F5659 /* DocumentCaptureScreen.swift in Sources */,
+				2F60973649978BCC01CC58E5 /* DocumentShapedBoundingBox.swift in Sources */,
+				69A80F96098F427328D67C89 /* ImagePicker.swift in Sources */,
+				4CA0E0025B9DE03228DABC81 /* OrchestratedDocumentVerificationScreen.swift in Sources */,
+				0B590B1435EA930EE91173BD /* FaceDetectionState.swift in Sources */,
+				69BAA6C270C9F637578D4EBE /* FaceDetector.swift in Sources */,
+				8F664FFEFE7D8B24CFD2E0E2 /* FaceGeometryModel.swift in Sources */,
+				96327D0A9A0709DBF07BE82E /* Colors.swift in Sources */,
+				81374F91F20B60478040EEA8 /* EnvironmentValues.swift in Sources */,
+				A8D4E9F6CEBCFF6636664430 /* EpilogueFont.swift in Sources */,
+				C308149CE75D38360C85D396 /* FontType.swift in Sources */,
+				BF30C6408B811AE443D02B0B /* ImageExtensions.swift in Sources */,
+				BDA19FC54581BB8F84CBC6A5 /* ImageUtils.swift in Sources */,
+				A70BED11848EEBE434EDF269 /* LocalStorage.swift in Sources */,
+				DE26C48EA39B3A750DBEFC69 /* LocalizedStringExtensions.swift in Sources */,
+				F3970D00683DA66B634DB5AC /* NavigationHelper.swift in Sources */,
+				9EF9680A731DD159CE103193 /* SmileIDLocalizableStrings.swift in Sources */,
+				6597B3F425DAE9E764469943 /* SmileIDResourcesHelper.swift in Sources */,
+				80AB81A9B2891E5049480782 /* StringConstants.swift in Sources */,
+				4A90E41DB56102E9935FAC7D /* Theme.swift in Sources */,
+				DFB30CE42D584CD582E50CBC /* NavigationBar.swift in Sources */,
+				065CFC14C26E343D5AA4CD99 /* APIError.swift in Sources */,
+				7764A236C7BE2920AAD9BC76 /* HTTPHeader.swift in Sources */,
+				924EEA7DE40BE422DBD65308 /* HTTPQueryParameters.swift in Sources */,
+				07EEE981C6890F7A323F972F /* Authentication.swift in Sources */,
+				23D624670B9009A30BECC772 /* BVN.swift in Sources */,
+				71BF786F646C0E887D2F2B6E /* Config.swift in Sources */,
+				F0815EC23DBD284D54248F0F /* EnhancedKyc.swift in Sources */,
+				6AF0939F8E7E5887791D6E43 /* JobStatus.swift in Sources */,
+				DD3D5CD49680452CA9FFFA10 /* JobType.swift in Sources */,
+				CF538DF6233B2B8F1E704602 /* PartnerParams.swift in Sources */,
+				8D293D146C020AE0BF0C241D /* PrepUpload.swift in Sources */,
+				D8A5950EBA40674B7EAE680E /* Services.swift in Sources */,
+				B6E8A46BF3DD46A8ABF6E39D /* UploadRequest.swift in Sources */,
+				2A81899E4657BDBC9F6D098E /* ValidDocuments.swift in Sources */,
+				509B7EA05CDA9C55EFF2B7A4 /* NetworkUtil.swift in Sources */,
+				61C413D7E1CB34A7334044A0 /* RestRequest.swift in Sources */,
+				121DFEFF548D011CBA7A84D3 /* RestServiceClient.swift in Sources */,
+				460156CA2759D18D5DF40EB4 /* ServiceHeaderProvider.swift in Sources */,
+				7B90ABB51D216087E51407EF /* ServiceRunnable.swift in Sources */,
+				4C50F52829A6A8A16EB0DFE7 /* SmileIDService.swift in Sources */,
+				D964186FCDA23D07DD254458 /* URLSessionPublisher.swift in Sources */,
+				4D6238CDBDAC25E6C6C22176 /* URLSessionRestServiceClient.swift in Sources */,
+				8A873930310EA017D4B3B1DA /* Quadrilateral.swift in Sources */,
+				96B59A7BBBA22914C38DD574 /* RectangleDectorFunnel.swift in Sources */,
+				1678F555BFD395B2D65148F6 /* RectangleDetector.swift in Sources */,
+				BCC549DD2D8E743A68288DE4 /* Transformable.swift in Sources */,
+				E5C7C5A3FB7314C7F695D44E /* RestartableTimer.swift in Sources */,
+				B45E839696B5A2536F432166 /* SelfieViewModel.swift in Sources */,
+				4435A31CE11AB9DBB5DFDD1B /* SmartSelfieResultDelegate.swift in Sources */,
+				C2B0688041FA7B785B53CD28 /* ARViewController.swift in Sources */,
+				0AC47C2ED1A6FC15E522A820 /* CameraView.swift in Sources */,
+				F55DAFF07CA748BB6B5A1A00 /* FaceShape.swift in Sources */,
+				C1193E04B56751E473207216 /* FaceShapedProgressIndicator.swift in Sources */,
+				46C46D364FF39204A3DDA2AA /* InfiniteProgressBar.swift in Sources */,
+				AF3625149CC1E70B172BCED0 /* OrchestratedSelfieCaptureScreen.swift in Sources */,
+				FDF540BC212C4AF6E9ED86DC /* SelfieCaptureScreen.swift in Sources */,
+				3CB4C2330F81DA7FC11FB600 /* SmartSelfieInstructionsScreen.swift in Sources */,
+				FF3DD3BC9F5FE8BCC6B75013 /* SmileButton.swift in Sources */,
+				FF6D86CAB80D887021C0C4C2 /* SelfieCaptureResultStore.swift in Sources */,
+				20BF2027B855E9BDD9DFDE7C /* SmileID.swift in Sources */,
+				29A11C12772969D59DFE3861 /* Util.swift in Sources */,
+				9E08E2DFC982580E22571A54 /* ActivityIndicator.swift in Sources */,
+				0A7BB6963FC2C07FBE2EED80 /* AspectRatioRoundedRectangle.swift in Sources */,
+				19D8E2ED7DC7021EB2B8EB3D /* ImageCaptureConfirmationDialog.swift in Sources */,
+				5541C4BD78990006336E810B /* JobSubmittable.swift in Sources */,
+				95CDD1F079266B71EA7B6832 /* ProcessingScreen.swift in Sources */,
+				FCFF9EC6481CE91DB7F610CA /* RadioGroupSelector.swift in Sources */,
+				6EDCE7DDEFDA1040B6EA34B2 /* SearchableDropdownSelector.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SmileID.xcodeproj/project.pbxproj
+++ b/SmileID.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		509B7EA05CDA9C55EFF2B7A4 /* NetworkUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153AB9A6C99A275245425516 /* NetworkUtil.swift */; };
 		52D9D812215568215D083200 /* DependencyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33582BC06C5A1BF366206851 /* DependencyResolver.swift */; };
 		5541C4BD78990006336E810B /* JobSubmittable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2057840F67E55D1CB5A304 /* JobSubmittable.swift */; };
+		5829A8C52BC8494F001C1E7E /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 5829A8C42BC8494F001C1E7E /* PrivacyInfo.xcprivacy */; };
 		59A6E2C084B5D3A2E5ADC3B5 /* EpilogueFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569F7887148BD143ED7AF657 /* EpilogueFont.swift */; };
 		5B2B787747FCFE4D7005AE12 /* HTTPQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB121D6B221D1F3B5F983F /* HTTPQueryParameters.swift */; };
 		5BEC9952C5C7600E626E4609 /* DocumentShapedBoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E6BC388D272353332F0EF4 /* DocumentShapedBoundingBox.swift */; };
@@ -1099,6 +1100,7 @@
 		580AFDE099C51F7C1B7E8410 /* LocalizedStringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalizedStringExtensions.swift; path = Sources/SmileID/Classes/Helpers/LocalizedStringExtensions.swift; sourceTree = "<group>"; };
 		5817992550DC9FCB3C9426FB /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = Sources/SmileID/Classes/Networking/Models/Services.swift; sourceTree = "<group>"; };
 		58185A4E9CDC79CE182ED7CB /* CameraViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraViewController.swift; path = Sources/SmileID/Classes/Camera/CameraViewController.swift; sourceTree = "<group>"; };
+		5829A8C42BC8494F001C1E7E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		584A51B9274189B7B98CA85D /* DocumentCaptureInstructionsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureInstructionsScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureInstructionsScreen.swift; sourceTree = "<group>"; };
 		584B7A345A1CD4F8865D8708 /* DocumentShapedBoundingBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentShapedBoundingBox.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentShapedBoundingBox.swift; sourceTree = "<group>"; };
 		5870CE32A6F07CC3A861744B /* DocumentCaptureScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentCaptureScreen.swift; path = Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift; sourceTree = "<group>"; };
@@ -4817,6 +4819,7 @@
 		1EEFC2BF2B58412300B8A934 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				5829A8C42BC8494F001C1E7E /* PrivacyInfo.xcprivacy */,
 				1EEFC2C02B58412300B8A934 /* Media.xcassets */,
 				1EEFC2C12B58412300B8A934 /* Fonts */,
 				1EEFC2C42B58412300B8A934 /* Localization */,
@@ -5015,6 +5018,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1EEFC2C72B58412300B8A934 /* .swiftlint.yml in Resources */,
+				5829A8C52BC8494F001C1E7E /* PrivacyInfo.xcprivacy in Resources */,
 				1EEFC3342B58412400B8A934 /* Localizable.strings in Resources */,
 				1EEFC3312B58412400B8A934 /* Media.xcassets in Resources */,
 				1EEFC3332B58412400B8A934 /* Epilogue-Bold.ttf in Resources */,

--- a/Sources/SmileID/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/SmileID/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeEnvironmentScanning</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeHead</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/12249

## Summary

Adds PrivacyInfo to SDK and Sample app. 

The attributes included for the SDK are: Head movement and Environment scanning; both for App functionality reasons. No Required Reason APIs. 

The attributes included for the sample app are: User ID; for App functionality. The Sentry dependency automatically adds the Crash Reporting attribute. No Required Reason APIs

## Known Issues

The xcframework generated by `./Scripts/build_frameworks.sh` doesn't contain the PrivacyInfo file currently