### PR TITLE
Chore: Expose skipApiSubmission in SmileID.smartSelfieEnrollmentScreen

### DIFF
--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -231,6 +231,7 @@ public class SmileID {
     ///     screen
     ///   - showInstructions: Whether to deactivate capture screen's instructions for SmartSelfie.
     ///   - extraPartnerParams: Custom values specific to partners
+    ///   - skipApiSubmission: Whether to skip submitting the captured selfie data to the server
     ///   - delegate: Callback to be invoked when the SmartSelfie™ Enrollment is complete.
     public class func smartSelfieEnrollmentScreen(
         userId: String = generateUserId(),

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -240,6 +240,7 @@ public class SmileID {
         showAttribution: Bool = true,
         showInstructions: Bool = true,
         extraPartnerParams: [String: String] = [:],
+        skipApiSubmission: Bool = false,
         delegate: SmartSelfieResultDelegate
     ) -> some View {
         OrchestratedSelfieCaptureScreen(
@@ -251,7 +252,7 @@ public class SmileID {
             showAttribution: showAttribution,
             showInstructions: showInstructions,
             extraPartnerParams: extraPartnerParams,
-            skipApiSubmission: false,
+            skipApiSubmission: skipApiSubmission,
             onResult: delegate
         )
     }


### PR DESCRIPTION
## Summary

This commit adds the implementation to `skipApiSubmission` in the `SmartSelfieEnrollment` flow, which allows users to decide whether or not they want to send submissions to Smile Identity Server.

Story: None

A few sentences/bullet points about the changes
- Exposed `skipApiSubmission` in `SmileID.smartSelfieEnrollmentScreen`
- Added test case for `skipApiSubmission`

## Known Issues
- Allow users to decide whether or not they want to send submissions to Smile Identity Server.
