### PR TITLE
Update filepaths when files move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 * Improved SmartSelfie Enrollment and Authentication times by moving to a synchronous API endpoint
 
+#### Fixed
+
+* Fixed a bug where invalid file paths were returned and retries did not work
+
 ## 10.1.3
 
 #### Fixed
 
-* Fix lottie SPM dependancy issues
+* Fix Lottie SPM dependency issues
 
 ## 10.1.2
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,13 @@
 PODS:
   - lottie-ios (4.4.3)
   - netfox (1.21.0)
-  - Sentry (8.20.0):
-    - Sentry/Core (= 8.20.0)
-    - SentryPrivate (= 8.20.0)
-  - Sentry/Core (8.20.0):
-    - SentryPrivate (= 8.20.0)
-  - SentryPrivate (8.20.0)
-  - SmileID (10.1.3):
+  - Sentry (8.26.0):
+    - Sentry/Core (= 8.26.0)
+  - Sentry/Core (8.26.0)
+  - SmileID (10.1.4):
     - lottie-ios (~> 4.4.2)
     - Zip (~> 2.1.0)
-  - SwiftLint (0.54.0)
+  - SwiftLint (0.55.1)
   - Zip (2.1.2)
 
 DEPENDENCIES:
@@ -24,7 +21,6 @@ SPEC REPOS:
     - lottie-ios
     - netfox
     - Sentry
-    - SentryPrivate
     - SwiftLint
     - Zip
 
@@ -35,10 +31,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
-  Sentry: a8d7b373b9f9868442b02a0c425192f693103cbf
-  SentryPrivate: 006b24af16828441f70e2ab6adf241bd0a8ad130
-  SmileID: 61ae985152b559099730bf211b74c9fbbcc4e516
-  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
+  Sentry: 74a073c71c998117edb08f56f443c83570a31bed
+  SmileID: 7aec4c8dea152260533e55672ad7ba04658f6cd0
+  SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
 PODFILE CHECKSUM: 8f7be2cf75babf479684f1e21d344f4c640486be

--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -461,7 +461,6 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SmileID_Example/Pods-SmileID_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
-				"${BUILT_PRODUCTS_DIR}/SentryPrivate/SentryPrivate.framework",
 				"${BUILT_PRODUCTS_DIR}/SmileID/SmileID.framework",
 				"${BUILT_PRODUCTS_DIR}/Zip/Zip.framework",
 				"${BUILT_PRODUCTS_DIR}/lottie-ios/Lottie.framework",
@@ -470,7 +469,6 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SentryPrivate.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SmileID.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Zip.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lottie.framework",

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '10.1.3'
+  s.version          = '10.1.4'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/ios-v10-beta'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Japhet' => 'japhet@usesmileid.com', 'Juma Allan' => 'juma@usesmileid.com', 'Vansh Gandhi' => 'vansh@usesmileid.com'}
-  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.1.3" }
+  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.1.4" }
   s.ios.deployment_target = '13.0'
   s.dependency 'Zip', '~> 2.1.0'
   s.dependency 'lottie-ios', '~> 4.4.2'

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -138,7 +138,7 @@ internal class OrchestratedBiometricKycViewModel: ObservableObject {
                         jobId: self.jobId,
                         error: error
                     )
-                    if (didMove) {
+                    if didMove {
                         self.selfieCaptureResultStore = SelfieCaptureResultStore(
                             selfie: try LocalStorage.getFileByType(
                                 jobId: jobId,

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -212,7 +212,7 @@ internal class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: Obse
                         jobId: self.jobId,
                         error: error
                     )
-                    if (didMove) {
+                    if didMove {
                         self.selfieFile = try LocalStorage.getFileByType(
                             jobId: jobId,
                             fileType: FileType.selfie,

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -190,6 +190,16 @@ internal class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: Obse
                 didSubmitJob = true
                 do {
                     try LocalStorage.moveToSubmittedJobs(jobId: self.jobId)
+                    self.selfieFile = try LocalStorage.getFileByType(
+                        jobId: jobId,
+                        fileType: FileType.selfie,
+                        submitted: true
+                    ) ?? selfieFile
+                    self.livenessFiles = try LocalStorage.getFilesByType(
+                        jobId: jobId,
+                        fileType: FileType.liveness,
+                        submitted: true
+                    ) ?? []
                 } catch {
                     print("Error moving job to submitted directory: \(error)")
                     self.onError(error: error)
@@ -198,10 +208,22 @@ internal class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: Obse
                 DispatchQueue.main.async { self.step = .processing(.success) }
             } catch let error as SmileIDError {
                 do {
-                    try LocalStorage.handleOfflineJobFailure(
+                    let didMove = try LocalStorage.handleOfflineJobFailure(
                         jobId: self.jobId,
                         error: error
                     )
+                    if (didMove) {
+                        self.selfieFile = try LocalStorage.getFileByType(
+                            jobId: jobId,
+                            fileType: FileType.selfie,
+                            submitted: true
+                        ) ?? selfieFile
+                        self.livenessFiles = try LocalStorage.getFilesByType(
+                            jobId: jobId,
+                            fileType: FileType.liveness,
+                            submitted: true
+                        ) ?? []
+                    }
                 } catch {
                     print("Error moving job to submitted directory: \(error)")
                     self.onError(error: error)

--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -360,6 +360,16 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
                 apiResponse = response
                 do {
                     try LocalStorage.moveToSubmittedJobs(jobId: self.jobId)
+                    self.selfieImage = try LocalStorage.getFileByType(
+                        jobId: jobId,
+                        fileType: FileType.selfie,
+                        submitted: true
+                    )
+                    self.livenessImages = try LocalStorage.getFilesByType(
+                        jobId: jobId,
+                        fileType: FileType.liveness,
+                        submitted: true
+                    ) ?? []
                 } catch {
                     print("Error moving job to submitted directory: \(error)")
                     self.error = error
@@ -367,10 +377,22 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
                 DispatchQueue.main.async { self.processingState = .success }
             } catch let error as SmileIDError {
                 do {
-                    try LocalStorage.handleOfflineJobFailure(
+                    let didMove = try LocalStorage.handleOfflineJobFailure(
                         jobId: self.jobId,
                         error: error
                     )
+                    if (didMove) {
+                        self.selfieImage = try LocalStorage.getFileByType(
+                            jobId: jobId,
+                            fileType: FileType.selfie,
+                            submitted: true
+                        )
+                        self.livenessImages = try LocalStorage.getFilesByType(
+                            jobId: jobId,
+                            fileType: FileType.liveness,
+                            submitted: true
+                        ) ?? []
+                    }
                 } catch {
                     print("Error moving job to submitted directory: \(error)")
                     self.error = error

--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -381,7 +381,7 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
                         jobId: self.jobId,
                         error: error
                     )
-                    if (didMove) {
+                    if didMove {
                         self.selfieImage = try LocalStorage.getFileByType(
                             jobId: jobId,
                             fileType: FileType.selfie,

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import UIKit
 
 public class SmileID {
-    public static let version = "10.1.3"
+    public static let version = "10.1.4"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
 

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -142,7 +142,8 @@ public class SmileID {
                 let authResponse = try await SmileID.api.authenticate(request: authRequest).async()
                 let prepUploadRequest = PrepUploadRequest(
                     partnerParams: authResponse.partnerParams.copy(extras: prepUploadFile.partnerParams.extras),
-                    allowNewEnroll: String(prepUploadFile.allowNewEnroll), // TODO: - Fix when Michael changes this to boolean
+                    // TODO: - Fix when Michael changes this to boolean
+                    allowNewEnroll: String(prepUploadFile.allowNewEnroll),
                     timestamp: authResponse.timestamp,
                     signature: authResponse.signature
                 )
@@ -151,7 +152,7 @@ public class SmileID {
                     LocalStorage.getFileByType(jobId: jobId, fileType: FileType.selfie),
                     LocalStorage.getFileByType(jobId: jobId, fileType: FileType.documentFront),
                     LocalStorage.getFileByType(jobId: jobId, fileType: FileType.documentBack),
-                    LocalStorage.getInfoJsonFile(jobId: jobId),
+                    LocalStorage.getInfoJsonFile(jobId: jobId)
                 ].compactMap { $0 }
                 let zipUrl = try LocalStorage.zipFiles(at: allFiles)
                 zip = try Data(contentsOf: zipUrl)


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/12858

## Summary

`handleOfflineJobFailure` now returns a boolean indicating whether files were moved. If they were, we update the file paths in the ViewModel using the result of `getFileByType` with `submitted=true`. getFileType was updated to add this new submitted parameter.

Prepares for 10.1.4 release