### PR TITLE
fix: change confidence value for smartselfie from double to strign

### DIFF
--- a/Sources/SmileID/Classes/Networking/Models/JobStatus.swift
+++ b/Sources/SmileID/Classes/Networking/Models/JobStatus.swift
@@ -148,7 +148,7 @@ public class SmartSelfieJobResult: JobResult {
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         guard let confidenceValue = try container.decodeIfPresent(String.self, forKey: .confidence) else {
-            throw SmileIDError.unknown("Decoding error")
+            throw SmileIDError.unknown("Error decoding .confidenceValue")
         }
         self.confidence =  Double(confidenceValue)
         try super.init(from: decoder)


### PR DESCRIPTION
Story: iOS Networking

## Summary

Change confidence value from double to string for smartselfie result as

## Known Issues

Still looking at all job types 

## Test Instructions

N/A

## Screenshot
<img width="448" alt="Screenshot 2024-06-03 at 11 25 23 PM" src="https://github.com/smileidentity/ios/assets/7263902/55950089-89ca-470e-a9a3-d6ef1b3357c7">

