### PR TITLE
Make Color Hex Initialiser Public

### DIFF
--- a/Sources/SmileID/Classes/Helpers/Colors.swift
+++ b/Sources/SmileID/Classes/Helpers/Colors.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension Color {
-    init(hex: String) {
+    public init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0
         Scanner(string: hex).scanHexInt64(&int)


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/12792

## Summary

Making the Color initialiser with hex value public will provide an easy way for customisation.

## Known Issues

N/A

## Test Instructions

Create a `CustomTheme` class that conforms to `SmileIDTheme` and override any of the computed color properties with a new Color initialised with a hex value.

## Screenshot

N/A
