### PR TITLE
Handle Unauthorised Camera Status

### DIFF
--- a/Sources/SmileID/Classes/Camera/CameraManager.swift
+++ b/Sources/SmileID/Classes/Camera/CameraManager.swift
@@ -39,7 +39,7 @@ class CameraManager: NSObject, ObservableObject {
     private let sessionQueue = DispatchQueue(label: "com.smileidentity.ios")
     private let videoOutput = AVCaptureVideoDataOutput()
     private let photoOutput = AVCapturePhotoOutput()
-    private var status = Status.unconfigured
+    @Published private(set) var status = Status.unconfigured
     private var orientation: Orientation
 
     init(orientation: Orientation) {
@@ -48,6 +48,7 @@ class CameraManager: NSObject, ObservableObject {
         sessionQueue.async {
             self.videoOutput.setSampleBufferDelegate(self, queue: self.videoOutputQueue)
         }
+        checkPermissions()
     }
 
     private func set(error: CameraError?) {

--- a/Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift
@@ -44,9 +44,10 @@ class DocumentCaptureViewModel: ObservableObject {
             idAspectRatio = defaultAspectRatio
         }
 
-        cameraManager.$error
+        cameraManager.$status
             .receive(on: DispatchQueue.main)
-            .map { AlertState(message: $0?.localizedDescription, title: "Camera error") }
+            .filter { $0 == .unauthorized }
+            .map { _ in AlertState.cameraUnauthorized }
             .sink { alert in self.unauthorizedAlert = alert }
             .store(in: &subscribers)
 

--- a/Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift
@@ -18,14 +18,14 @@ class DocumentCaptureViewModel: ObservableObject {
     // Other properties
     private let defaultAspectRatio: Double
     private let textDetector = TextDetector()
-    private var imageCaptureSubscriber: AnyCancellable?
-    private var cameraBufferSubscriber: AnyCancellable?
+    private var subscribers = Set<AnyCancellable>()
     private var processingImage = false
     private var documentFirstDetectedAtTime: TimeInterval?
     private var lastAnalysisTime: TimeInterval = 0
     private var areEdgesDetectedSubscriber: AnyCancellable?
 
     // UI properties
+    @Published var unauthorizedAlert: AlertState?
     @Published var acknowledgedInstructions = false
     @Published var showPhotoPicker = false
     @Published var directive: DocumentDirective = .defaultInstructions
@@ -44,15 +44,23 @@ class DocumentCaptureViewModel: ObservableObject {
             idAspectRatio = defaultAspectRatio
         }
 
-        imageCaptureSubscriber = cameraManager.capturedImagePublisher
+        cameraManager.$error
+            .receive(on: DispatchQueue.main)
+            .map { AlertState(message: $0?.localizedDescription, title: "Camera error") }
+            .sink { alert in self.unauthorizedAlert = alert }
+            .store(in: &subscribers)
+
+        cameraManager.capturedImagePublisher
             .receive(on: DispatchQueue.global())
             .compactMap { $0 }
             .sink(receiveValue: onCaptureComplete)
+            .store(in: &subscribers)
 
-        cameraBufferSubscriber = cameraManager.sampleBufferPublisher
+        cameraManager.sampleBufferPublisher
             .receive(on: DispatchQueue(label: "com.smileidentity.receivebuffer"))
             .compactMap { $0 }
             .sink(receiveValue: analyzeImage)
+            .store(in: &subscribers)
 
         // Show Manual Capture button after 10 seconds
         Timer.scheduledTimer(
@@ -247,5 +255,10 @@ class DocumentCaptureViewModel: ObservableObject {
         let isCenteredVertically = deltaY < tolerance
 
         return isCenteredHorizontally && isCenteredVertically
+    }
+    
+    func openSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(settingsURL)
     }
 }

--- a/Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift
@@ -94,17 +94,17 @@ public struct DocumentCaptureScreen: View {
                 cameraManager: viewModel.cameraManager,
                 onCaptureClick: viewModel.captureDocument
             )
-            .alert(item: $viewModel.alert) { alert in
+            .alert(item: $viewModel.unauthorizedAlert) { alert in
                 Alert(
-                    title: Text("App name Needs Access to Your Camera"),
-                    message: Text("The camera permission is required to complete the verification process"),
-                    primaryButton: .cancel(),
-                    secondaryButton: .default(
-                        Text("Open Settings"),
+                    title: Text(alert.title),
+                    message: Text(alert.message ?? ""),
+                    primaryButton: .default(
+                        Text(SmileIDResourcesHelper.localizedString(for: "Camera.Unauthorized.PrimaryAction")),
                         action: {
                             viewModel.openSettings()
                         }
-                    )
+                    ),
+                    secondaryButton: .cancel()
                 )
             }
         }

--- a/Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/View/DocumentCaptureScreen.swift
@@ -94,6 +94,19 @@ public struct DocumentCaptureScreen: View {
                 cameraManager: viewModel.cameraManager,
                 onCaptureClick: viewModel.captureDocument
             )
+            .alert(item: $viewModel.alert) { alert in
+                Alert(
+                    title: Text("App name Needs Access to Your Camera"),
+                    message: Text("The camera permission is required to complete the verification process"),
+                    primaryButton: .cancel(),
+                    secondaryButton: .default(
+                        Text("Open Settings"),
+                        action: {
+                            viewModel.openSettings()
+                        }
+                    )
+                )
+            }
         }
     }
 }

--- a/Sources/SmileID/Classes/Helpers/AlertState.swift
+++ b/Sources/SmileID/Classes/Helpers/AlertState.swift
@@ -1,13 +1,28 @@
 import Foundation
 
+/// A type representing the state necessary to display a native iOS alert.
 struct AlertState: Identifiable {
     let id: UUID
-    let message: String?
     let title: String
-    
-    init(id: UUID = UUID(), message: String? = nil, title: String) {
+    let message: String?
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        message: String? = nil
+    ) {
         self.id = id
-        self.message = message
         self.title = title
+        self.message = message
+    }
+}
+
+extension AlertState {
+    /// A static property representing an alert state for unauthorized camera access.
+    static var cameraUnauthorized: Self {
+        AlertState(
+            title: SmileIDResourcesHelper.localizedString(for: "Camera.Unauthorized.Title"),
+            message: SmileIDResourcesHelper.localizedString(for: "Camera.Unauthorized.Message")
+        )
     }
 }

--- a/Sources/SmileID/Classes/Helpers/AlertState.swift
+++ b/Sources/SmileID/Classes/Helpers/AlertState.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct AlertState: Identifiable {
+    let id: UUID
+    let message: String?
+    let title: String
+    
+    init(id: UUID = UUID(), message: String? = nil, title: String) {
+        self.id = id
+        self.message = message
+        self.title = title
+    }
+}

--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -74,10 +74,10 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
         self.skipApiSubmission = skipApiSubmission
         self.extraPartnerParams = extraPartnerParams
 
-        cameraManager.$error
+        cameraManager.$status
             .receive(on: DispatchQueue.main)
-            // .filter { $0 == .unauthorized }
-            .map { AlertState(message: $0?.localizedDescription, title: "Camera error") }
+            .filter { $0 == .unauthorized }
+            .map { _ in AlertState.cameraUnauthorized }
             .sink { alert in self.unauthorizedAlert = alert }
             .store(in: &subscribers)
 

--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -44,6 +44,7 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
     private var subscribers = Set<AnyCancellable>()
 
     // UI Properties
+    @Published var unauthorizedAlert: AlertState?
     @Published var directive: String = "Instructions.Start"
     /// we use `errorMessageRes` to map to the actual code to the stringRes to allow localization,
     /// and use `errorMessage` to show the actual platform error message that we show if
@@ -72,6 +73,14 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
         self.allowNewEnroll = allowNewEnroll
         self.skipApiSubmission = skipApiSubmission
         self.extraPartnerParams = extraPartnerParams
+
+        cameraManager.$error
+            .receive(on: DispatchQueue.main)
+            // .filter { $0 == .unauthorized }
+            .map { AlertState(message: $0?.localizedDescription, title: "Camera error") }
+            .sink { alert in self.unauthorizedAlert = alert }
+            .store(in: &subscribers)
+
         cameraManager.sampleBufferPublisher
             .merge(with: arKitFramePublisher)
             .throttle(for: 0.35, scheduler: DispatchQueue.global(qos: .userInitiated), latest: true)
@@ -435,5 +444,10 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
         } else {
             callback.didError(error: SmileIDError.unknown("Unknown error"))
         }
+    }
+    
+    func openSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(settingsURL)
     }
 }

--- a/Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift
@@ -50,17 +50,17 @@ public struct SelfieCaptureScreen: View {
             }
                 .padding(24)
         }
-        .alert(item: $viewModel.alert) { alert in
+        .alert(item: $viewModel.unauthorizedAlert) { alert in
             Alert(
-                title: Text("App name Needs Access to Your Camera"),
-                message: Text("The camera permission is required to complete the verification process"),
-                primaryButton: .cancel(),
-                secondaryButton: .default(
-                    Text("Open Settings"),
+                title: Text(alert.title),
+                message: Text(alert.message ?? ""),
+                primaryButton: .default(
+                    Text(SmileIDResourcesHelper.localizedString(for: "Camera.Unauthorized.PrimaryAction")),
                     action: {
                         viewModel.openSettings()
                     }
-                )
+                ),
+                secondaryButton: .cancel()
             )
         }
     }

--- a/Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/SelfieCaptureScreen.swift
@@ -50,5 +50,18 @@ public struct SelfieCaptureScreen: View {
             }
                 .padding(24)
         }
+        .alert(item: $viewModel.alert) { alert in
+            Alert(
+                title: Text("App name Needs Access to Your Camera"),
+                message: Text("The camera permission is required to complete the verification process"),
+                primaryButton: .cancel(),
+                secondaryButton: .default(
+                    Text("Open Settings"),
+                    action: {
+                        viewModel.openSettings()
+                    }
+                )
+            )
+        }
     }
 }

--- a/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
@@ -47,6 +47,9 @@
 "Action.Skip" = "Skip back of ID";
 
 "Camera.AgentMode" = "Agent Mode";
+"Camera.Unauthorized.Title" = "Allow access to your camera";
+"Camera.Unauthorized.Message" = "The camera permission is required to complete the verification process.";
+"Camera.Unauthorized.PrimaryAction" = "Open Settings";
 
 "Document.Confirmation.Header" = "Is the document clear and readable?";
 "Document.Confirmation.Callout" = "Make sure all corners of the document are visible and there is no glare";


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/13056

## Summary

This includes the following changes:
* Introduce a new type to hold a state for native alert.
* Handle unauthorised camera status and present a native alert with an action that would take users to app settings.
* Add new localised strings for the unauthorised alert content.

## Known Issues

N/A

## Test Instructions

If you already have the Example app, you can go to the app settings and toggle off camera permission for the Example app or deny camera permission if it's a fresh install. Then try running a job that requires camera access (Selfie or Document verification). You should see an alert that tells you camera access is needed and tapping on the Open Settings button should take you back to the app settings.

## Screenshot

| Selfie Job | Document Verification |
| --- | --- |
| <img src="https://github.com/smileidentity/ios/assets/8595853/7f7efebd-076c-4523-8558-26117d8411d5" /> | <img src="https://github.com/smileidentity/ios/assets/8595853/536498da-9e54-4d95-a1a7-156587f3d763" /> |
