### PR TITLE
Fix Jobs User Id issue

### DIFF
--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -873,7 +873,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99P7YGX9Q6;
@@ -906,7 +906,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99P7YGX9Q6;

--- a/Example/SmileID/Home/HomeView.swift
+++ b/Example/SmileID/Home/HomeView.swift
@@ -63,7 +63,7 @@ struct HomeView: View {
                                 EnhancedKycWithIdInputScreen(
                                     delegate: viewModel,
                                     viewModel: EnhancedKycWithIdInputScreenViewModel(
-                                        userId: viewModel.smartSelfieEnrollmentUserId,
+                                        userId: viewModel.newUserId,
                                         jobId: viewModel.newJobId
                                     )
                                 )
@@ -79,7 +79,7 @@ struct HomeView: View {
                                 BiometricKycWithIdInputScreen(
                                     delegate: viewModel,
                                     viewModel: BiometricKycWithIdInputScreenViewModel(
-                                        userId: viewModel.smartSelfieEnrollmentUserId,
+                                        userId: viewModel.newUserId,
                                         jobId: viewModel.newJobId
                                     )
                                 )
@@ -93,7 +93,7 @@ struct HomeView: View {
                             },
                             content: {
                                 DocumentVerificationWithSelector(
-                                    userId: viewModel.smartSelfieEnrollmentUserId,
+                                    userId: viewModel.newUserId,
                                     jobId: viewModel.newJobId,
                                     delegate: viewModel
                                 )
@@ -107,7 +107,7 @@ struct HomeView: View {
                             },
                             content: {
                                 EnhancedDocumentVerificationWithSelector(
-                                    userId: viewModel.smartSelfieEnrollmentUserId,
+                                    userId: viewModel.newUserId,
                                     jobId: viewModel.newJobId,
                                     delegate: viewModel
                                 )

--- a/Example/SmileID/Home/HomeViewModel.swift
+++ b/Example/SmileID/Home/HomeViewModel.swift
@@ -20,6 +20,7 @@ class HomeViewModel: ObservableObject,
     @ObservedObject var networkMonitor = NetworkMonitor.shared
 
     @Published private(set) var smartSelfieEnrollmentUserId = generateUserId()
+    @Published private(set) var newUserId: String = generateUserId()
     @Published private(set) var newJobId: String = generateJobId()
 
     let dataStoreClient: DataStoreClient
@@ -40,7 +41,8 @@ class HomeViewModel: ObservableObject,
     }
 
     func onProductClicked() {
-        // Update jobId whenever a new job is about to be initiated.
+        // Update userId and jobId whenever a new job is about to be initiated.
+        newUserId = generateUserId()
         newJobId = generateJobId()
         if !networkMonitor.isConnected {
             toastMessage = "No internet connection"
@@ -150,7 +152,7 @@ class HomeViewModel: ObservableObject,
                 data: JobData(
                     jobType: .biometricKyc,
                     timestamp: Date(),
-                    userId: smartSelfieEnrollmentUserId,
+                    userId: newUserId,
                     jobId: newJobId
                 )
             )
@@ -204,7 +206,7 @@ class HomeViewModel: ObservableObject,
                 data: JobData(
                     jobType: .documentVerification,
                     timestamp: Date(),
-                    userId: smartSelfieEnrollmentUserId,
+                    userId: newUserId,
                     jobId: newJobId
                 )
             )
@@ -230,7 +232,7 @@ class HomeViewModel: ObservableObject,
                 data: JobData(
                     jobType: .enhancedDocumentVerification,
                     timestamp: Date(),
-                    userId: smartSelfieEnrollmentUserId,
+                    userId: newUserId,
                     jobId: newJobId
                 )
             )

--- a/Example/SmileID/Jobs/JobItemModel.swift
+++ b/Example/SmileID/Jobs/JobItemModel.swift
@@ -16,7 +16,11 @@ class JobItemModel: ObservableObject {
     }
 
     private func sendAuthenticationRequest() async throws -> AuthenticationResponse {
-        let authRequest = AuthenticationRequest(jobType: job.jobType)
+        let authRequest = AuthenticationRequest(
+            jobType: job.jobType,
+            jobId: job.jobId,
+            userId: job.userId
+        )
         return try await SmileID.api.authenticate(request: authRequest)
     }
 

--- a/Example/SmileID/Jobs/JobsView.swift
+++ b/Example/SmileID/Jobs/JobsView.swift
@@ -22,12 +22,14 @@ struct JobsView: View {
             .navigationTitle("Jobs")
             .toolbar {
                 ToolbarItem {
-                    Button(action: {
-                        viewModel.clearButtonTapped()
-                    }, label: {
-                        Image(systemName: "trash.fill")
-                    })
-                    .buttonStyle(.plain)
+                    if !viewModel.jobs.isEmpty {
+                        Button(action: {
+                            viewModel.clearButtonTapped()
+                        }, label: {
+                            Image(systemName: "trash.fill")
+                        })
+                        .buttonStyle(.plain)
+                    }
                 }
             }
             .onAppear {


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/12793/

## Summary

* Use newly generated userId for authentication jobs instead of smart selfie enrolment userId
* Hide clear jobs button if there are no jobs.

## Known Issues

N/A.

## Test Instructions

N/A

## Screenshot

N/A
