### PR TITLE
Refresh Entire App when Smile Config is Updated

### DIFF
--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -881,7 +881,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99P7YGX9Q6;
@@ -914,7 +914,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99P7YGX9Q6;

--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		20B6D5E32C21C3C90023D51C /* Job.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B6D5E12C21C3C90023D51C /* Job.swift */; };
 		20B6D5EA2C21CA9E0023D51C /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B6D5E92C21CA9E0023D51C /* CoreDataManager.swift */; };
 		20B6D5EC2C21CE660023D51C /* DataStoreError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B6D5EB2C21CE660023D51C /* DataStoreError.swift */; };
+		20C360C82C454C130008DBDE /* RootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C360C72C454C130008DBDE /* RootViewModel.swift */; };
 		20DFA0EC2C21917100AC2AE7 /* View+TextSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DFA0EB2C21917100AC2AE7 /* View+TextSelection.swift */; };
 		20F3D6F32C25F4D700B32751 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		20F3D6F62C25F5C100B32751 /* SmileID.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 20F3D6F42C25F5C100B32751 /* SmileID.xcdatamodeld */; };
@@ -114,6 +115,7 @@
 		20B6D5E12C21C3C90023D51C /* Job.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Job.swift; sourceTree = "<group>"; };
 		20B6D5E92C21CA9E0023D51C /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		20B6D5EB2C21CE660023D51C /* DataStoreError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreError.swift; sourceTree = "<group>"; };
+		20C360C72C454C130008DBDE /* RootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewModel.swift; sourceTree = "<group>"; };
 		20DFA0EB2C21917100AC2AE7 /* View+TextSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+TextSelection.swift"; sourceTree = "<group>"; };
 		20F3D6F52C25F5C100B32751 /* SmileID.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SmileID.xcdatamodel; sourceTree = "<group>"; };
 		262BF9A8643DF9220FD233E3 /* Pods-SmileID_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SmileID_Example.release.xcconfig"; path = "Target Support Files/Pods-SmileID_Example/Pods-SmileID_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 			isa = PBXGroup;
 			children = (
 				1ED53F622A2F28590020BEFB /* RootView.swift */,
+				20C360C72C454C130008DBDE /* RootViewModel.swift */,
 				1E60ED352A29C306002695FF /* AppDelegate.swift */,
 			);
 			path = App;
@@ -699,6 +702,7 @@
 				20343AF22C206CEC003536F5 /* JobData.swift in Sources */,
 				205FB4A72C2C32A500FDE64F /* JobItemModel.swift in Sources */,
 				6AC9870BB28E40FCACC75947 /* DocumentVerificationIdTypeSelector.swift in Sources */,
+				20C360C82C454C130008DBDE /* RootViewModel.swift in Sources */,
 				205FB4A52C29AF1500FDE64F /* Date+Extensions.swift in Sources */,
 				6AC98F5682012E19C815AE70 /* DocumentSelectorViewModel.swift in Sources */,
 				6AC983F056A8F9088D6CF3F7 /* SettingsView.swift in Sources */,

--- a/Example/SmileID/App/RootViewModel.swift
+++ b/Example/SmileID/App/RootViewModel.swift
@@ -10,7 +10,7 @@ class RootViewModel: ObservableObject {
     )
     private let jsonDecoder = JSONDecoder()
 
-    init(config: Config? = nil) {
+    init() {
         // It is possible the app was built without a smile_config, so it may be null
         let builtInConfig = Bundle.main.url(forResource: "smile_config", withExtension: "json")
             .flatMap {

--- a/Example/SmileID/App/RootViewModel.swift
+++ b/Example/SmileID/App/RootViewModel.swift
@@ -1,0 +1,32 @@
+import SmileID
+import SwiftUI
+
+class RootViewModel: ObservableObject {
+    @Published private(set) var decodedConfig: Config?
+
+    // This is set by the SettingsView
+    @AppStorage("smileConfig") private var configJson = (
+        UserDefaults.standard.string(forKey: "smileConfig") ?? ""
+    )
+    private let jsonDecoder = JSONDecoder()
+
+    init(config: Config? = nil) {
+        // It is possible the app was built without a smile_config, so it may be null
+        let builtInConfig = Bundle.main.url(forResource: "smile_config", withExtension: "json")
+            .flatMap {
+                try? jsonDecoder.decode(Config.self, from: Data(contentsOf: $0))
+            }
+        let configFromUserStorage = try? jsonDecoder.decode(
+            Config.self,
+            from: configJson.data(using: .utf8)!
+        )
+
+        // If a config was set at runtime (i.e. saved in UserStorage) prioritize that. Fallback to
+        // the built-in config if not set. Otherwise, ask the user to set a config.
+        self.decodedConfig = configFromUserStorage ?? builtInConfig
+    }
+
+    func updateConfig(config: Config) {
+        self.decodedConfig = config
+    }
+}

--- a/Example/SmileID/Jobs/JobListItem.swift
+++ b/Example/SmileID/Jobs/JobListItem.swift
@@ -129,8 +129,10 @@ struct JobListItem: View {
     }
 }
 
+#if DEBUG
 #Preview {
     JobListItem(
         model: JobItemModel(job: .documentVerification)
     )
 }
+#endif

--- a/Example/SmileID/Jobs/JobsView.swift
+++ b/Example/SmileID/Jobs/JobsView.swift
@@ -2,7 +2,7 @@ import SmileID
 import SwiftUI
 
 struct JobsView: View {
-    @StateObject var viewModel: JobsViewModel
+    @ObservedObject var viewModel: JobsViewModel
 
     var body: some View {
         NavigationView {

--- a/Example/SmileID/Settings/SettingsView.swift
+++ b/Example/SmileID/Settings/SettingsView.swift
@@ -2,7 +2,7 @@ import SmileID
 import SwiftUI
 
 struct SettingsView: View {
-    @ObservedObject private var viewModel = SettingsViewModel()
+    @ObservedObject var viewModel: SettingsViewModel
 
     var body: some View {
         NavigationView {
@@ -67,6 +67,6 @@ private struct SettingsCell: View {
 
 private struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView()
+        SettingsView(viewModel: SettingsViewModel(didUpdateConfig: { _ in }))
     }
 }

--- a/Example/SmileID/Settings/SettingsViewModel.swift
+++ b/Example/SmileID/Settings/SettingsViewModel.swift
@@ -7,18 +7,25 @@ class SettingsViewModel: ObservableObject {
 
     private let jsonDecoder = JSONDecoder()
 
+    var didUpdateConfig: (Config) -> Void
+
+    init(didUpdateConfig: @escaping (Config) -> Void) {
+        self.didUpdateConfig = didUpdateConfig
+    }
+
     func onUpdateSmileConfigSelected() {
         DispatchQueue.main.async { self.showSheet = true }
     }
 
     func updateSmileConfig(_ configJson: String) {
         do {
-            _ = try jsonDecoder.decode(Config.self, from: configJson.data(using: .utf8)!)
+            let updatedConfig = try jsonDecoder.decode(Config.self, from: configJson.data(using: .utf8)!)
             UserDefaults.standard.set(configJson, forKey: "smileConfig")
             DispatchQueue.main.async {
                 self.errorMessage = nil
                 self.showSheet = false
             }
+            self.didUpdateConfig(updatedConfig)
         } catch {
             print("Error decoding new config: \(error)")
             DispatchQueue.main.async { self.errorMessage = "Invalid Config" }


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

* move smile config decoding and initialisation into root view model. 
* add a closure to send back update config to root view so that the entire app is refreshed.

## Known Issues

N/A.

## Test Instructions

* Launch the app with configuration already applied.
* Go to Settings and update smile config with another partner information.
* Go to Home Screen to see that the partner information has been updated
* If you have jobs saved locally, the Jobs list screen should also reflect the change.

## Screenshot

N/A
