### PR TITLE
Set retry flag on error code 2215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Add new cases to `ActionResult` including an unknown case to handle values that do not match the defined enum cases.
 * Add a custom decoding initializer to ActionResult that supports defaulting unexpected values to the unknown case.
 
+#### Fixed
+
+* Fixed a bug where `SmileID.submitJob` would not work for previously attempted API requests
+
 ## 10.2.2
 
 #### Fixed

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - lottie-ios (4.4.3)
   - netfox (1.21.0)
-  - Sentry (8.26.0):
-    - Sentry/Core (= 8.26.0)
-  - Sentry/Core (8.26.0)
+  - Sentry (8.31.1):
+    - Sentry/Core (= 8.31.1)
+  - Sentry/Core (8.31.1)
   - SmileID (10.2.2):
     - lottie-ios (~> 4.4.2)
     - Zip (~> 2.1.0)
@@ -31,7 +31,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
-  Sentry: 74a073c71c998117edb08f56f443c83570a31bed
+  Sentry: 9c1188876ea1291d1a9db4b38c3f17ebd8e6985e
   SmileID: 9d95463475f933422b2ce136474813b528dbedb7
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67

--- a/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
+++ b/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
@@ -50,6 +50,21 @@ public struct PrepUploadRequest: Codable {
         case signature
         case retry
     }
+
+    public func copy(retry: String? = nil) -> PrepUploadRequest {
+        return PrepUploadRequest(
+            partnerParams: partnerParams,
+            callbackUrl: callbackUrl,
+            allowNewEnroll: allowNewEnroll,
+            partnerId: partnerId,
+            sourceSdk: sourceSdk,
+            sourceSdkVersion: sourceSdkVersion,
+            timestamp: timestamp,
+            signature: signature,
+            useEnrolledImage: useEnrolledImage,
+            retry: retry ?? self.retry
+        )
+    }
 }
 
 public struct PrepUploadResponse: Codable {

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -147,7 +147,21 @@ public class SmileID {
                     timestamp: authResponse.timestamp,
                     signature: authResponse.signature
                 )
-                let prepUploadResponse = try await SmileID.api.prepUpload(request: prepUploadRequest)
+                let prepUploadResponse: PrepUploadResponse
+                do {
+                    prepUploadResponse = try await SmileID.api.prepUpload(
+                        request: prepUploadRequest
+                    )
+                } catch let error as SmileIDError {
+                    switch error {
+                    case .api("2215", _):
+                        prepUploadResponse = try await SmileID.api.prepUpload(
+                            request: prepUploadRequest.copy(retry: "true")
+                        )
+                    default:
+                        throw error
+                    }
+                }
                 let allFiles: [URL]
                 do {
                     let livenessFiles = try LocalStorage.getFilesByType(jobId: jobId, fileType: .liveness) ?? []


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/13152

## Summary

The link returned by Prep Upload has an expiration. However, the job is still considered created at the time the link expires. So, if the user encounters a scenario where prep upload succeeds but upload fails, and the partner app's implementation tries again using `SmileID.submitJob`, it currently fails with error code 2215. 


With this change, we check for this error code explicitly and set the retry flag to true so that we can obtain a new upload URL

Related: https://github.com/smileidentity/android/pull/411