### PR TITLE
feat: consistent paths

### DIFF
--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -343,7 +343,8 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
                     smartSelfieLivenessImages.append(contentsOf: livenessImageInfos.compactMap { $0 })
                 }
                 guard let smartSelfieImage = smartSelfieImage,
-                smartSelfieLivenessImages.count == numLivenessImages else {
+                      smartSelfieLivenessImages.count == numLivenessImages
+                else {
                     throw SmileIDError.unknown("Selfie capture failed")
                 }
                 let response = if isEnroll {
@@ -433,13 +434,19 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
     }
 
     func onFinished(callback: SmartSelfieResultDelegate) {
-        if let selfieImage, livenessImages.count == numLivenessImages {
+        if let selfieImage = selfieImage,
+           let selfiePath = getRelativePath(from: selfieImage),
+           livenessImages.count == numLivenessImages,
+           !livenessImages.contains(where: { getRelativePath(from: $0) == nil })
+        {
+            let livenessImagesPaths = livenessImages.compactMap { getRelativePath(from: $0) }
+
             callback.didSucceed(
-                selfieImage: selfieImage,
-                livenessImages: livenessImages,
+                selfieImage: selfiePath,
+                livenessImages: livenessImagesPaths,
                 apiResponse: apiResponse
             )
-        } else if let error {
+        } else if let error = error {
             callback.didError(error: error)
         } else {
             callback.didError(error: SmileIDError.unknown("Unknown error"))


### PR DESCRIPTION
Story: N/A

## Summary

Make selfie file paths consistent with other products, we always get the files in the same directory so in the results the docv enhanceddocv  , biometric kyc models will still work fine 

## Known Issues

I'm adding an extension to be used by the wrappers

## Test Instructions

* Smartselfie enrollment should return the relative file paths
* Enhanced Doc V should work fine
* Biometric KYC should work fine 

## Screenshot
<img width="1215" alt="Screenshot 2024-08-23 at 4 47 43 PM" src="https://github.com/user-attachments/assets/4d3ce3ac-c65d-477a-8ce9-b7d2f6b1a9b6">
<img width="991" alt="Screenshot 2024-08-23 at 4 48 01 PM" src="https://github.com/user-attachments/assets/48aaf35d-d703-4498-a99a-7fd70edeee8a">


