### PR TITLE
feat: prepupload extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 10.2.8
+
+### Changed
+* Smartselfie captures now return relative file urls as the rest of the products
+
+### Added
+* Zip files from prepupload request
+
 ## 10.2.7
 
 ### Changed

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - Sentry (8.32.0):
     - Sentry/Core (= 8.32.0)
   - Sentry/Core (8.32.0)
-  - SmileID (10.2.7):
+  - SmileID (10.2.8):
     - lottie-ios (~> 4.4.2)
     - ZIPFoundation (~> 0.9)
   - SwiftLint (0.55.1)
@@ -43,7 +43,7 @@ SPEC CHECKSUMS:
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
   Sentry: 96ae1dcdf01a644bc3a3b1dc279cecaf48a833fb
-  SmileID: 500429946fbb916221450c9f792fa94ee1060955
+  SmileID: 8d3a64e845a5fb82239516def978391d4d814c9e
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '10.2.7'
+  s.version          = '10.2.8'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/ios-v10-beta'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import UIKit
 
 public class SmileID {
-    public static let version = "10.2.7"
+    public static let version = "10.2.8"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
 


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/12554/ios-integrate-with-new-zip-library

## Summary

* Bump version to 2.1.8
* Prepupload zip files for use on wrappers

## Known Issues

N/A

## Test Instructions

When prepupload is provided, this will extract the job id and add a info.json if found then return the zip data
