### PR TITLE
Add Upload Request Timeout, Fix API Error Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## [Unreleased]
+
+### Changed
+* Convert network service upload function to normal async/await from AsyncThrowingStream.
+* Handle requestError with URLError and return localizedDescription for user facing alert message.
+* Handle httpError and provide a user facing message for the alert.
+
 ## 10.2.9
 
 ### Added

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -46,7 +46,7 @@ internal class OrchestratedBiometricKycViewModel: ObservableObject {
     }
 
     func onRetry() {
-        if let selfieFile {
+        if selfieFile != nil {
             submitJob()
         } else {
             DispatchQueue.main.async { self.step = .selfie }
@@ -56,8 +56,7 @@ internal class OrchestratedBiometricKycViewModel: ObservableObject {
     func onFinished(delegate: BiometricKycResultDelegate) {
         if let selfieFile = selfieFile,
            let livenessFiles = livenessFiles,
-           let selfiePath = getRelativePath(from: selfieFile)
-        {
+           let selfiePath = getRelativePath(from: selfieFile) {
             delegate.didSucceed(
                 selfieImage: selfiePath,
                 livenessImages: livenessFiles.compactMap { getRelativePath(from: $0) },
@@ -143,7 +142,7 @@ internal class OrchestratedBiometricKycViewModel: ObservableObject {
                         throw error
                     }
                 }
-                _ = try await SmileID.api.upload(
+                let _ = try await SmileID.api.upload(
                     zip: zipData,
                     to: prepUploadResponse.uploadUrl
                 )
@@ -179,9 +178,11 @@ internal class OrchestratedBiometricKycViewModel: ObservableObject {
                     print("Error submitting job: \(error)")
                     let (errorMessageRes, errorMessage) = toErrorMessage(error: error)
                     self.error = error
-                    self.errorMessageRes = errorMessageRes
-                    self.errorMessage = errorMessage
-                    DispatchQueue.main.async { self.step = .processing(.error) }
+                    DispatchQueue.main.async {
+                        self.errorMessageRes = errorMessageRes
+                        self.errorMessage = errorMessage
+                        self.step = .processing(.error)
+                    }
                 }
             } catch {
                 didSubmitBiometricJob = false

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -78,19 +78,19 @@ internal class OrchestratedBiometricKycViewModel: ObservableObject {
                     jobId: jobId,
                     fileType: FileType.selfie
                 )
-            
+
                 livenessFiles = try LocalStorage.getFilesByType(
                     jobId: jobId,
                     fileType: FileType.liveness
                 )
-            
+
                 guard let selfieFile else {
                     // Set step to .selfieCapture so that the Retry button goes back to this step
                     DispatchQueue.main.async { self.step = .selfie }
                     error = SmileIDError.unknown("Error capturing selfie")
                     return
                 }
-            
+
                 var allFiles = [URL]()
                 let infoJson = try LocalStorage.createInfoJsonFile(
                     jobId: jobId,

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -115,28 +115,28 @@ internal class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: Obse
                     onError(error: SmileIDError.unknown("Error getting document front file"))
                     return
                 }
-            
+
                 selfieFile = try LocalStorage.getFileByType(
                     jobId: jobId,
                     fileType: FileType.selfie
                 )
-            
+
                 livenessFiles = try LocalStorage.getFilesByType(
                     jobId: jobId,
                     fileType: FileType.liveness
                 )
-            
+
                 guard let selfieFile else {
                     // Set step to .selfieCapture so that the Retry button goes back to this step
                     step = .selfieCapture
                     onError(error: SmileIDError.unknown("Error getting selfie file"))
                     return
                 }
-            
+
                 DispatchQueue.main.async {
                     self.step = .processing(.inProgress)
                 }
-        
+
                 var allFiles = [URL]()
                 let frontDocumentUrl = try LocalStorage.createDocumentFile(
                     jobId: jobId,
@@ -316,7 +316,7 @@ internal class OrchestratedDocumentVerificationViewModel:
     IOrchestratedDocumentVerificationViewModel<DocumentVerificationResultDelegate, DocumentVerificationJobResult>
 {
     override func onFinished(delegate: DocumentVerificationResultDelegate) {
-        if let savedFiles, 
+        if let savedFiles,
             let selfiePath = getRelativePath(from: selfieFile),
             let documentFrontPath = getRelativePath(from: savedFiles.documentFront),
             let documentBackPath = getRelativePath(from: savedFiles.documentBack)

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -212,7 +212,7 @@ internal class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: Obse
                         throw error
                     }
                 }
-                _ = try await SmileID.api.upload(
+                let _ = try await SmileID.api.upload(
                     zip: zipData,
                     to: prepUploadResponse.uploadUrl
                 )

--- a/Sources/SmileID/Classes/Networking/APIError.swift
+++ b/Sources/SmileID/Classes/Networking/APIError.swift
@@ -11,6 +11,7 @@ public enum SmileIDError: Error {
     case consentDenied
     case invalidJobId
     case fileNotFound(String)
+    case invalidRequestBody
 }
 
 extension SmileIDError: LocalizedError {
@@ -36,6 +37,8 @@ extension SmileIDError: LocalizedError {
             return "Invalid jobId or not found"
         case .fileNotFound(let message):
             return message
+        case .invalidRequestBody:
+            return "Invalid request body. The request data is missing or empty."
         }
     }
 }

--- a/Sources/SmileID/Classes/Networking/RestServiceClient.swift
+++ b/Sources/SmileID/Classes/Networking/RestServiceClient.swift
@@ -3,5 +3,5 @@ import Foundation
 protocol RestServiceClient {
     func send<T: Decodable>(request: RestRequest) async throws -> T
     func multipart<T: Decodable>(request: RestRequest) async throws -> T
-    func upload(request: RestRequest) async throws -> AsyncThrowingStream<UploadResponse, Error>
+    func upload(request: RestRequest) async throws -> Data
 }

--- a/Sources/SmileID/Classes/Networking/RestServiceClient.swift
+++ b/Sources/SmileID/Classes/Networking/RestServiceClient.swift
@@ -3,5 +3,10 @@ import Foundation
 protocol RestServiceClient {
     func send<T: Decodable>(request: RestRequest) async throws -> T
     func multipart<T: Decodable>(request: RestRequest) async throws -> T
+    /// Uploads the given `RestRequest` asynchronously and returns the response data.
+    /// 
+    /// - Parameter request: The `RestRequest` object containing the details of the request to be uploaded.
+    /// - Returns: The response data from the server.
+    /// - Throws: An error if the upload fails.
     func upload(request: RestRequest) async throws -> Data
 }

--- a/Sources/SmileID/Classes/Networking/ServiceRunnable.swift
+++ b/Sources/SmileID/Classes/Networking/ServiceRunnable.swift
@@ -42,7 +42,7 @@ protocol ServiceRunnable {
         data: Data,
         to url: String,
         with restMethod: RestMethod
-    ) async throws -> AsyncThrowingStream<UploadResponse, Error>
+    ) async throws -> Data
 }
 
 extension ServiceRunnable {
@@ -145,7 +145,7 @@ extension ServiceRunnable {
         data: Data,
         to url: String,
         with restMethod: RestMethod
-    ) async throws -> AsyncThrowingStream<UploadResponse, Error> {
+    ) async throws -> Data {
         let uploadRequest = try await createUploadRequest(
             url: url,
             method: restMethod,

--- a/Sources/SmileID/Classes/Networking/SmileIDService.swift
+++ b/Sources/SmileID/Classes/Networking/SmileIDService.swift
@@ -10,7 +10,7 @@ public protocol SmileIDServiceable {
     func prepUpload(request: PrepUploadRequest) async throws -> PrepUploadResponse
 
     /// Uploads files to S3. The URL should be the one returned by `prepUpload`.
-    func upload(zip: Data, to url: String) async throws -> AsyncThrowingStream<UploadResponse, Error>
+    func upload(zip: Data, to url: String) async throws -> Data
 
     /// Perform a synchronous SmartSelfie Enrollment. The response will include the final result of
     /// the enrollment.
@@ -258,7 +258,7 @@ public class SmileIDService: SmileIDServiceable, ServiceRunnable {
         )
     }
 
-    public func upload(zip: Data, to url: String) async throws -> AsyncThrowingStream<UploadResponse, Error> {
+    public func upload(zip: Data, to url: String) async throws -> Data {
         try await upload(data: zip, to: url, with: .put)
     }
 

--- a/Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift
+++ b/Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift
@@ -13,14 +13,14 @@ class URLSessionRestServiceClient: NSObject, RestServiceClient {
     typealias URLSessionResponse = (data: Data, response: URLResponse)
     let session: URLSessionPublisher
     let decoder = JSONDecoder()
-    let uploadRequestTimeout: TimeInterval
+    let requestTimeout: TimeInterval
 
     public init(
-        session: URLSessionPublisher = URLSession.shared,
-        uploadRequestTimeout: TimeInterval = SmileID.defaultUploadRequestTimeout
+        session: URLSessionPublisher,
+        requestTimeout: TimeInterval = SmileID.defaultRequestTimeout
     ) {
         self.session = session
-        self.uploadRequestTimeout = uploadRequestTimeout
+        self.requestTimeout = requestTimeout
     }
 
     func send<T: Decodable>(request: RestRequest) async throws -> T {
@@ -42,7 +42,7 @@ class URLSessionRestServiceClient: NSObject, RestServiceClient {
         do {
             let urlRequest = try request.getUploadRequest()
             let configuration = URLSessionConfiguration.default
-            configuration.timeoutIntervalForRequest = uploadRequestTimeout
+            configuration.timeoutIntervalForRequest = requestTimeout
             let uploadSession = URLSession(configuration: configuration)
 
             let urlSessionResponse = try await uploadSession.upload(for: urlRequest, from: requestBody)

--- a/Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift
+++ b/Sources/SmileID/Classes/Networking/URLSession/URLSessionRestServiceClient.swift
@@ -74,7 +74,7 @@ class URLSessionRestServiceClient: NSObject, RestServiceClient {
             return .unknown(error.localizedDescription)
         }
     }
-    
+
     private struct ErrorResponse: Codable {
         let error: String
     }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -55,7 +55,8 @@ public class SmileID {
     ///   - config: The smile config file. If no value is supplied, we check the app's main bundle
     ///    for a `smile_config.json` file.
     ///   - useSandbox: A boolean to enable the sandbox environment or not
-    ///   - requestTimeout: The timeout interval for all requests. An interval greater than `defaultRequestTimeout` is recommended.
+    ///   - requestTimeout: The timeout interval for all requests.
+    ///   An interval greater than `defaultRequestTimeout` is recommended.
     public class func initialize(
         config: Config = getConfig(),
         useSandbox: Bool = false,
@@ -76,7 +77,8 @@ public class SmileID {
     ///   - config: The smile config file. If no value is supplied, we check the app's main bundle
     ///    for a `smile_config.json` file.
     ///   - useSandbox: A boolean to enable the sandbox environment or not
-    ///   - requestTimeout: The timeout interval for all requests. An interval greater than `defaultRequestTimeout` is recommended.
+    ///   - requestTimeout: The timeout interval for all requests. 
+    ///   An interval greater than `defaultRequestTimeout` is recommended.
     public class func initialize(
         apiKey: String? = nil,
         config: Config = getConfig(),

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -55,7 +55,7 @@ public class SmileID {
     ///   - config: The smile config file. If no value is supplied, we check the app's main bundle
     ///    for a `smile_config.json` file.
     ///   - useSandbox: A boolean to enable the sandbox environment or not
-    ///   - requestTimeout: The timeout interval for upload requests.
+    ///   - requestTimeout: The timeout interval for all requests. An interval greater than `defaultRequestTimeout` is recommended.
     public class func initialize(
         config: Config = getConfig(),
         useSandbox: Bool = false,
@@ -76,7 +76,7 @@ public class SmileID {
     ///   - config: The smile config file. If no value is supplied, we check the app's main bundle
     ///    for a `smile_config.json` file.
     ///   - useSandbox: A boolean to enable the sandbox environment or not
-    ///   - requestTimeout: The timeout interval for upload requests.
+    ///   - requestTimeout: The timeout interval for all requests. An interval greater than `defaultRequestTimeout` is recommended.
     public class func initialize(
         apiKey: String? = nil,
         config: Config = getConfig(),

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -143,7 +143,6 @@ public class SmileID {
             throw SmileIDError.fileNotFound("Prep Upload file is missing")
         }
         Task {
-            let zip: Data
             do {
                 let authRequest = AuthenticationRequest(
                     jobType: authRequestFile.jobType,

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -3,6 +3,8 @@ import SwiftUI
 import UIKit
 
 public class SmileID {
+    /// The default value for `timeoutIntervalForRequest` for URLSession default configuration.
+    public static let defaultUploadRequestTimeout: TimeInterval = 60
     public static let version = "10.2.9"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
@@ -12,7 +14,11 @@ public class SmileID {
     static let instance: SmileID = {
         let container = DependencyContainer.shared
         container.register(SmileIDServiceable.self) { SmileIDService() }
-        container.register(RestServiceClient.self) { URLSessionRestServiceClient() }
+        container.register(RestServiceClient.self) {
+            URLSessionRestServiceClient(
+                uploadRequestTimeout: SmileID.uploadRequestTimeout
+            )
+        }
         container.register(ServiceHeaderProvider.self) { DefaultServiceHeaderProvider() }
         let instance = SmileID()
         return instance
@@ -27,6 +33,8 @@ public class SmileID {
     static var apiKey: String?
     public private(set) static var theme: SmileIdTheme = DefaultTheme()
     private(set) static var localizableStrings: SmileIDLocalizableStrings?
+    /// The timeout interval for upload requests. This value is initialized to the `defaultUploadRequestTimeout`.
+    private(set) static var uploadRequestTimeout: TimeInterval = SmileID.defaultUploadRequestTimeout
 
     /// This method initializes SmileID. Invoke this method once in your application lifecycle
     /// before calling any other SmileID methods.
@@ -34,11 +42,18 @@ public class SmileID {
     ///   - config: The smile config file. If no value is supplied, we check the app's main bundle
     ///    for a `smile_config.json` file.
     ///   - useSandbox: A boolean to enable the sandbox environment or not
+    ///   - uploadRequestTimeout: The timeout interval for upload requests.
     public class func initialize(
         config: Config = getConfig(),
-        useSandbox: Bool = false
+        useSandbox: Bool = false,
+        uploadRequestTimeout: TimeInterval = SmileID.defaultUploadRequestTimeout
     ) {
-        initialize(apiKey: nil, config: config, useSandbox: useSandbox)
+        initialize(
+            apiKey: nil,
+            config: config,
+            useSandbox: useSandbox,
+            uploadRequestTimeout: uploadRequestTimeout
+        )
     }
 
     /// This method initializes SmileID. Invoke this method once in your application lifecylce
@@ -48,14 +63,17 @@ public class SmileID {
     ///   - config: The smile config file. If no value is supplied, we check the app's main bundle
     ///    for a `smile_config.json` file.
     ///   - useSandbox: A boolean to enable the sandbox environment or not
+    ///   - uploadRequestTimeout: The timeout interval for upload requests.
     public class func initialize(
         apiKey: String? = nil,
         config: Config = getConfig(),
-        useSandbox: Bool = false
+        useSandbox: Bool = false,
+        uploadRequestTimeout: TimeInterval = SmileID.defaultUploadRequestTimeout
     ) {
         self.config = config
         self.useSandbox = useSandbox
         self.apiKey = apiKey
+        self.uploadRequestTimeout = uploadRequestTimeout
         SmileIDResourcesHelper.registerFonts()
     }
 

--- a/Sources/SmileID/Classes/Util.swift
+++ b/Sources/SmileID/Classes/Util.swift
@@ -62,7 +62,7 @@ func toErrorMessage(error: SmileIDError) -> (String, String?) {
         return (errorMessage, message)
     case let .request(error):
         return (error.localizedDescription, nil)
-    case .httpError(let code, let message):
+    case .httpError(_, let message):
         return ("", message)
     default:
         return ("Confirmation.FailureReason", nil)

--- a/Sources/SmileID/Classes/Util.swift
+++ b/Sources/SmileID/Classes/Util.swift
@@ -60,6 +60,8 @@ func toErrorMessage(error: SmileIDError) -> (String, String?) {
     case .api(let code, let message):
         let errorMessage = "Si.Error.Message.\(code)"
         return (errorMessage, message)
+    case let .request(error):
+        return (error.localizedDescription, nil)
     default:
         return ("Confirmation.FailureReason", nil)
     }

--- a/Sources/SmileID/Classes/Views/JobSubmittable.swift
+++ b/Sources/SmileID/Classes/Views/JobSubmittable.swift
@@ -34,7 +34,7 @@ extension JobSubmittable {
     func upload(
         _ prepUploadResponse: PrepUploadResponse,
         zip: Data
-    ) async throws -> AsyncThrowingStream<UploadResponse, Error> {
+    ) async throws -> Data {
         try await SmileID.api.upload(zip: zip, to: prepUploadResponse.uploadUrl)
     }
 

--- a/Tests/Mocks/NetworkingMocks.swift
+++ b/Tests/Mocks/NetworkingMocks.swift
@@ -58,14 +58,11 @@ class MockSmileIdentityService: SmileIDServiceable {
         }
     }
 
-    func upload(zip _: Data = Data(), to _: String = "") async throws -> AsyncThrowingStream<UploadResponse, Error> {
-        return AsyncThrowingStream { continuation in
-            let response = UploadResponse.response(data: Data())
-            if MockHelper.shouldFail {
-                continuation.finish(throwing: SmileIDError.request(URLError(.resourceUnavailable)))
-            } else {
-                continuation.yield(response)
-            }
+    func upload(zip _: Data = Data(), to _: String = "") async throws -> Data {
+        if MockHelper.shouldFail {
+            throw SmileIDError.request(URLError(.resourceUnavailable))
+        } else {
+            return Data()
         }
     }
 


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/13466/

## Summary

* Add a new argument for SmileID initialiser to specify timeout for upload requests.
* Refactor upload method to use async await instead of AsyncThrowingStream.
* Handle URLError and show localizedDescription to users.

## Known Issues

Confirm that timeout errors are handled.

## Test Instructions

* In HomeViewModel add a short `uploadRequestTimeout` argument to the SmileID initialiser like 1sec.
* Run a job that involves upload requests
* The job should time out.

## Screenshot

https://portal.usesmileid.com/admin/job/production/172668761
