### PR TITLE
Feature/smilescreens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Release Notes
+## 10.2.12
+
+### Added
+* Modified access for selfie instruction screen for use in wrappers
+
 ## 10.2.11
 
 ### Added

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - Sentry (8.36.0):
     - Sentry/Core (= 8.36.0)
   - Sentry/Core (8.36.0)
-  - SmileID (10.2.11):
+  - SmileID (10.2.12):
     - FingerprintJS
     - lottie-ios (~> 4.4.2)
     - ZIPFoundation (~> 0.9)
@@ -51,7 +51,7 @@ SPEC CHECKSUMS:
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
   Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
-  SmileID: 6222ec839420b69917ae23ea11876d78d2529620
+  SmileID: 6a7309335dafa915a23a6c4e8bfa4742aa483fc8
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '10.2.11'
+  s.version          = '10.2.12'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/ios-v10-beta'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Japhet' => 'japhet@usesmileid.com', 'Juma Allan' => 'juma@usesmileid.com', 'Vansh Gandhi' => 'vansh@usesmileid.com'}
-  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.2.11" }
+  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.2.12" }
   s.ios.deployment_target = '13.0'
   s.dependency 'ZIPFoundation', '~> 0.9'
   s.dependency 'FingerprintJS'

--- a/Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/SmartSelfieInstructionsScreen.swift
@@ -7,8 +7,12 @@ import SwiftUI
 ///    - showAttribution: Whether or not to show the SmileID attribution
 ///    - onInstructionsAcknowledged: The callback to invoke when the user acknowledges the instructions
 public struct SmartSelfieInstructionsScreen: View {
-    let showAttribution: Bool
-    let onInstructionsAcknowledged: () -> Void
+    public let showAttribution: Bool
+    public let onInstructionsAcknowledged: () -> Void
+    public init(showAttribution: Bool, onInstructionsAcknowledged: @escaping () -> Void) {
+        self.showAttribution = showAttribution
+        self.onInstructionsAcknowledged = onInstructionsAcknowledged
+    }
 
     public var body: some View {
         VStack {
@@ -30,7 +34,7 @@ public struct SmartSelfieInstructionsScreen: View {
                             .lineSpacing(1.3)
                             .fixedSize(horizontal: false, vertical: true)
                     }
-                        .padding(.bottom, 48)
+                    .padding(.bottom, 48)
 
                     VStack(alignment: .leading, spacing: 32) {
                         HStack(spacing: 16) {
@@ -39,16 +43,16 @@ public struct SmartSelfieInstructionsScreen: View {
                                 Text(SmileIDResourcesHelper.localizedString(
                                     for: "Instructions.GoodLight"
                                 ))
-                                    .font(SmileID.theme.header4)
-                                    .foregroundColor(SmileID.theme.accent)
+                                .font(SmileID.theme.header4)
+                                .foregroundColor(SmileID.theme.accent)
                                 Text(SmileIDResourcesHelper.localizedString(
                                     for: "Instructions.GoodLightBody"
                                 ))
-                                    .multilineTextAlignment(.leading)
-                                    .font(SmileID.theme.header5)
-                                    .foregroundColor(SmileID.theme.tertiary)
-                                    .lineSpacing(1.3)
-                                    .fixedSize(horizontal: false, vertical: true)
+                                .multilineTextAlignment(.leading)
+                                .font(SmileID.theme.header5)
+                                .foregroundColor(SmileID.theme.tertiary)
+                                .lineSpacing(1.3)
+                                .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                         HStack(spacing: 16) {
@@ -57,16 +61,16 @@ public struct SmartSelfieInstructionsScreen: View {
                                 Text(SmileIDResourcesHelper.localizedString(
                                     for: "Instructions.ClearImage"
                                 ))
-                                    .font(SmileID.theme.header4)
-                                    .foregroundColor(SmileID.theme.accent)
+                                .font(SmileID.theme.header4)
+                                .foregroundColor(SmileID.theme.accent)
                                 Text(SmileIDResourcesHelper.localizedString(
                                     for: "Instructions.ClearImageBody"
                                 ))
-                                    .multilineTextAlignment(.leading)
-                                    .font(SmileID.theme.header5)
-                                    .foregroundColor(SmileID.theme.tertiary)
-                                    .lineSpacing(1.3)
-                                    .fixedSize(horizontal: false, vertical: true)
+                                .multilineTextAlignment(.leading)
+                                .font(SmileID.theme.header5)
+                                .foregroundColor(SmileID.theme.tertiary)
+                                .lineSpacing(1.3)
+                                .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                         HStack(spacing: 16) {
@@ -75,16 +79,16 @@ public struct SmartSelfieInstructionsScreen: View {
                                 Text(SmileIDResourcesHelper.localizedString(
                                     for: "Instructions.RemoveObstructions"
                                 ))
-                                    .font(SmileID.theme.header4)
-                                    .foregroundColor(SmileID.theme.accent)
+                                .font(SmileID.theme.header4)
+                                .foregroundColor(SmileID.theme.accent)
                                 Text(SmileIDResourcesHelper.localizedString(
                                     for: "Instructions.RemoveObstructionsBody"
                                 ))
-                                    .multilineTextAlignment(.leading)
-                                    .font(SmileID.theme.header5)
-                                    .foregroundColor(SmileID.theme.tertiary)
-                                    .lineSpacing(1.3)
-                                    .fixedSize(horizontal: false, vertical: true)
+                                .multilineTextAlignment(.leading)
+                                .font(SmileID.theme.header5)
+                                .foregroundColor(SmileID.theme.tertiary)
+                                .lineSpacing(1.3)
+                                .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                     }
@@ -102,7 +106,7 @@ public struct SmartSelfieInstructionsScreen: View {
                 }
             }
         }
-            .padding(.horizontal, 16)
-            .preferredColorScheme(.light)
+        .padding(.horizontal, 16)
+        .preferredColorScheme(.light)
     }
 }


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/13199/allow-wrappers-sdks-to-capture-face-images-separately-v10-react-vs-flutter

## Summary

Selfie capture UI without the whole flow and optionally can show or hide the confirmation dialog before returning the file paths

## Known Issues

Need to release https://github.com/smileidentity/ios/pull/231 for iOS to be complete 

## Test Instructions

There is a new button with title Selfie Capture click and capture should return the file paths on both android and iOS
1. Show attrition
2. Show confirmation
3. File paths should match the provided job id

## Screenshot


