### PR TITLE
Potential Fix for Freezing Image Analysis

### DIFF
--- a/Example/SmileID/Home/HomeView.swift
+++ b/Example/SmileID/Home/HomeView.swift
@@ -4,11 +4,10 @@ import SwiftUI
 struct HomeView: View {
     let version = SmileID.version
     let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
-    @ObservedObject var viewModel: HomeViewModel
-    @ObservedObject var networkMonitor = NetworkMonitor.shared
+    @StateObject var viewModel: HomeViewModel
 
     init(config: Config) {
-        viewModel = HomeViewModel(config: config)
+        _viewModel =  StateObject(wrappedValue: HomeViewModel(config: config))
     }
 
     var body: some View {

--- a/Example/SmileID/Home/HomeViewModel.swift
+++ b/Example/SmileID/Home/HomeViewModel.swift
@@ -17,7 +17,7 @@ class HomeViewModel: ObservableObject,
     @Published var toastMessage = ""
     @Published var showToast = false
     @Published var partnerId: String
-    @ObservedObject var networkMonitor = NetworkMonitor.shared
+    var networkMonitor = NetworkMonitor.shared
 
     @Published private(set) var smartSelfieEnrollmentUserId = generateUserId()
     @Published private(set) var newUserId: String = generateUserId()


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/12173/

## Summary

This change is a potential fix for a lot of state management issues in the Example app and it should minimise the number of times the HomeViewModel is reinitialised restricting view re-render to just when certain properties within the scope change rather than refreshing the entire application when any property changes.
* Replace `ObservedObject` with `StateObject`. 
* Get rid of unused `networkMonitor` variable in `HomeViewModel`

## Known Issues

N/A.

## Test Instructions

N/A.

## Screenshot

N/A
