### PR TITLE
Update Partner Config without Relaunching Demo App

### DIFF
--- a/Example/SmileID/Home/HomeView.swift
+++ b/Example/SmileID/Home/HomeView.swift
@@ -4,10 +4,10 @@ import SwiftUI
 struct HomeView: View {
     let version = SmileID.version
     let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
-    @StateObject var viewModel: HomeViewModel
+    @ObservedObject var viewModel: HomeViewModel
 
     init(config: Config) {
-        _viewModel = StateObject(wrappedValue: HomeViewModel(config: config))
+        self.viewModel = HomeViewModel(config: config)
     }
 
     let columns = [GridItem(.flexible()), GridItem(.flexible())]


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

* Change StateObject to ObservedObject so that injected config can re-render the view.

## Known Issues

N/A.

## Test Instructions

* Launch the Demo app and switch to the Settings.
* Tap on "Update Smile Config"
* Provide partner config with a string or QR code
* Switch back to Home Tab to see the current partner config info.
* You should see the update without having to relaunch the app.
* Please also test the jobs to be sure that this change doesn't break anything on your device. (Jobs are working fine on mine).

## Screenshot

If applicable (e.g. UI changes), add screenshots to help explain your work.
