### PR TITLE
Fix Required Document Back Image Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Release Notes
 
-## [Unrealeased]
+## 10.4.0
 
 ### Added
 * Default headers to all GET and POST requests: PartnerID, Source SDK and Source SDK Version.
 * SentryClient setup to capture errors in the SDK with SentryHub without interferring with host application.
+
+### Fixed
+* Document back image required when `captureBothSides` is false.
 
 ## 10.3.4
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - Sentry (8.43.0):
     - Sentry/Core (= 8.43.0)
   - Sentry/Core (8.43.0)
-  - SmileID (10.3.4):
+  - SmileID (10.4.0):
     - FingerprintJS
     - lottie-ios (~> 4.4.2)
     - Sentry (~> 8.43.0)
@@ -52,7 +52,7 @@ SPEC CHECKSUMS:
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
   Sentry: 532b281a53b1b45a523fd592f608956fb36e577c
-  SmileID: 02f77395d92ccc01ef138782af0282cba5206fd1
+  SmileID: 9f9570e7b010a8e63e8d695299544b10c9921b02
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '10.3.4'
+  s.version          = '10.4.0'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/ios-v10-beta'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Japhet' => 'japhet@usesmileid.com', 'Juma Allan' => 'juma@usesmileid.com', 'Vansh Gandhi' => 'vansh@usesmileid.com', 'Tobi Omotayo' => 'oluwatobi@usesmileid.com' }
-  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.3.4" }
+  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.4.0" }
   s.ios.deployment_target = '13.0'
   s.dependency 'ZIPFoundation', '~> 0.9'
   s.dependency 'FingerprintJS'

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -334,9 +334,8 @@ class OrchestratedDocumentVerificationViewModel:
     override func onFinished(delegate: DocumentVerificationResultDelegate) {
         if let savedFiles,
            let selfiePath = getRelativePath(from: selfieFile),
-           let documentFrontPath = getRelativePath(from: savedFiles.documentFront),
-           let documentBackPath = getRelativePath(from: savedFiles.documentBack)
-        {
+           let documentFrontPath = getRelativePath(from: savedFiles.documentFront) {
+            let documentBackPath = getRelativePath(from: savedFiles.documentBack)
             delegate.didSucceed(
                 selfie: selfiePath,
                 documentFrontImage: documentFrontPath,
@@ -362,9 +361,8 @@ class OrchestratedEnhancedDocumentVerificationViewModel:
     override func onFinished(delegate: EnhancedDocumentVerificationResultDelegate) {
         if let savedFiles,
            let selfiePath = getRelativePath(from: selfieFile),
-           let documentFrontPath = getRelativePath(from: savedFiles.documentFront),
-           let documentBackPath = getRelativePath(from: savedFiles.documentBack)
-        {
+           let documentFrontPath = getRelativePath(from: savedFiles.documentFront) {
+            let documentBackPath = getRelativePath(from: savedFiles.documentBack)
             delegate.didSucceed(
                 selfie: selfiePath,
                 documentFrontImage: documentFrontPath,

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -6,7 +6,7 @@ import UIKit
 public class SmileID {
     /// The default value for `timeoutIntervalForRequest` for URLSession default configuration.
     public static let defaultRequestTimeout: TimeInterval = 60
-    public static let version = "10.3.3"
+    public static let version = "10.3.4"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
 

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -6,7 +6,7 @@ import UIKit
 public class SmileID {
     /// The default value for `timeoutIntervalForRequest` for URLSession default configuration.
     public static let defaultRequestTimeout: TimeInterval = 60
-    public static let version = "10.3.4"
+    public static let version = "10.4.0"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
 

--- a/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
@@ -120,7 +120,6 @@
 "Si.Error.Message.2203" = "";
 "Si.Error.Message.2204" = "";
 "Si.Error.Message.2205" = "";
-"Si.Error.Message.2206" = "";
 "Si.Error.Message.2405" = "";
 "Si.Error.Message.2207" = "";
 "Si.Error.Message.2208" = "";

--- a/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/SmileID/Resources/Localization/en.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 "Si.Error.Message.2203" = "";
 "Si.Error.Message.2204" = "";
 "Si.Error.Message.2205" = "";
+"Si.Error.Message.2206" = "";
 "Si.Error.Message.2405" = "";
 "Si.Error.Message.2207" = "";
 "Si.Error.Message.2208" = "";


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/14901/

## Summary

* The back image for document was required for the success method of document verification result delegate but it shouldn't be because there is a flag `captureBothSides` that allows only front of a document to be captured. Made this not required

## Known Issues

N/A.

## Test Instructions

- When initiating document verification orchestrated flow in the SDK pass a false value to the `captureBothSides` flag
- Run a document verification job and tap continue button after selfie capture. 
- The flow should be dismissed without an unknown error.

## Screenshot

N/A
