### PR TITLE
Fix Selfie Capture Update Issue

### DIFF
--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -93,6 +93,7 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
             .store(in: &subscribers)
 
         cameraManager.sampleBufferPublisher
+            .receive(on: DispatchQueue.main)
             .merge(with: arKitFramePublisher)
             .throttle(
                 for: 0.35, scheduler: DispatchQueue.global(qos: .userInitiated),

--- a/Sources/SmileID/Classes/SelfieCapture/View/OrchestratedSelfieCaptureScreen.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/View/OrchestratedSelfieCaptureScreen.swift
@@ -8,7 +8,7 @@ public struct OrchestratedSelfieCaptureScreen: View {
     public let showAttribution: Bool
     public let showInstructions: Bool
     public let onResult: SmartSelfieResultDelegate
-    @ObservedObject var viewModel: SelfieViewModel
+    @Backport.StateObject var viewModel: SelfieViewModel
 
     @State private var localMetadata = LocalMetadata()
     @State private var acknowledgedInstructions = false
@@ -30,14 +30,16 @@ public struct OrchestratedSelfieCaptureScreen: View {
         self.showAttribution = showAttribution
         self.showInstructions = showInstructions
         self.onResult = onResult
-        viewModel = SelfieViewModel(
-            isEnroll: isEnroll,
-            userId: userId,
-            jobId: jobId,
-            allowNewEnroll: allowNewEnroll,
-            skipApiSubmission: skipApiSubmission,
-            extraPartnerParams: extraPartnerParams,
-            localMetadata: LocalMetadata()
+        self._viewModel = Backport.StateObject(
+            wrappedValue: SelfieViewModel(
+                isEnroll: isEnroll,
+                userId: userId,
+                jobId: jobId,
+                allowNewEnroll: allowNewEnroll,
+                skipApiSubmission: skipApiSubmission,
+                extraPartnerParams: extraPartnerParams,
+                localMetadata: LocalMetadata()
+            )
         )
     }
 


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

* Use state object for selfie viewmodel so that it isn't initialised multiple times.

## Known Issues

N/A.

## Test Instructions

N/A.

## Screenshot

N/A
