### PR TITLE
Use StateObject for SDK Views

### DIFF
--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycScreen.swift
@@ -11,7 +11,7 @@ struct OrchestratedBiometricKycScreen: View {
     let useStrictMode: Bool
     let extraPartnerParams: [String: String] = [:]
     let delegate: BiometricKycResultDelegate
-    @ObservedObject private var viewModel: OrchestratedBiometricKycViewModel
+    @Backport.StateObject private var viewModel: OrchestratedBiometricKycViewModel
 
     init(
         idInfo: IdInfo,
@@ -34,7 +34,7 @@ struct OrchestratedBiometricKycScreen: View {
         self.allowAgentMode = allowAgentMode
         self.useStrictMode = useStrictMode
         self.delegate = delegate
-        viewModel = OrchestratedBiometricKycViewModel(
+        self._viewModel = Backport.StateObject(wrappedValue: OrchestratedBiometricKycViewModel(
             userId: userId,
             jobId: jobId,
             allowNewEnroll: allowNewEnroll,
@@ -42,7 +42,7 @@ struct OrchestratedBiometricKycScreen: View {
             useStrictMode: useStrictMode,
             consentInformation: consentInformation,
             extraPartnerParams: extraPartnerParams
-        )
+        ))
     }
 
     var body: some View {

--- a/Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/View/OrchestratedDocumentVerificationScreen.swift
@@ -133,7 +133,7 @@ private struct IOrchestratedDocumentVerificationScreen<T, U: JobResult>: View {
     let useStrictMode: Bool
     var extraPartnerParams: [String: String]
     let onResult: T
-    @ObservedObject var viewModel: IOrchestratedDocumentVerificationViewModel<T, U>
+    @Backport.StateObject var viewModel: IOrchestratedDocumentVerificationViewModel<T, U>
 
     init(
         countryCode: String,
@@ -172,7 +172,7 @@ private struct IOrchestratedDocumentVerificationScreen<T, U: JobResult>: View {
         self.useStrictMode = useStrictMode
         self.extraPartnerParams = extraPartnerParams
         self.onResult = onResult
-        self.viewModel = viewModel
+        self._viewModel = Backport.StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

* use stateobject for orchestrated biometric and docv to avoid multiple instances at a time and improve memory.

## Known Issues

N/A.

## Test Instructions

Test all Document Verification and Biometric KYC and all jobs should be submit successfully.

## Screenshot

N/A.
