### PR TITLE
feat:skip api submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes
 ## 10.4.2
 
-* Added SmartSelfie™ capture only option for for Enhanced SmartSelfie™ and SmartSelfie™ capture flows without submission accessible with `skipApiSubmission=true` on enroll and authentication products
+* Added SmartSelfie™ capture only option for Enhanced SmartSelfie™ and SmartSelfie™ capture flows without submission accessible with `skipApiSubmission=true` on enroll and authentication products
 
 ## 10.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes
 ## 10.4.2
 
-* Added SmartSelfie™ capture only option for for Enhanced SmartSelfie™ and SmartSelfie™ capture flows without submission 
+* Added SmartSelfie™ capture only option for Enhanced SmartSelfie™ and SmartSelfie™ capture flows without submission 
 
 ## 10.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Release Notes
+## 10.4.2
+
+* Added SmartSelfie™ capture only option for for Enhanced SmartSelfie™ and SmartSelfie™ capture flows without submission 
 
 ## 10.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes
 ## 10.4.2
 
-* Added SmartSelfie™ capture only option for Enhanced SmartSelfie™ and SmartSelfie™ capture flows without submission 
+* Added SmartSelfie™ capture only option for for Enhanced SmartSelfie™ and SmartSelfie™ capture flows without submission accessible with `skipApiSubmission=true` on enroll and authentication products
 
 ## 10.4.1
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - Sentry (8.43.0):
     - Sentry/Core (= 8.43.0)
   - Sentry/Core (8.43.0)
-  - SmileID (10.4.1):
+  - SmileID (10.4.2):
     - FingerprintJS
     - lottie-ios (~> 4.4.2)
     - ZIPFoundation (~> 0.9)
@@ -51,7 +51,7 @@ SPEC CHECKSUMS:
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
   Sentry: 532b281a53b1b45a523fd592f608956fb36e577c
-  SmileID: 50ec8cfe392348978359e4606fad4e52793b0481
+  SmileID: d65cea02b08bc293ba6324b617d7a08ab2d0348f
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '10.4.1'
+  s.version          = '10.4.2'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/ios-v10-beta'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Japhet' => 'japhet@usesmileid.com', 'Juma Allan' => 'juma@usesmileid.com', 'Vansh Gandhi' => 'vansh@usesmileid.com', 'Tobi Omotayo' => 'oluwatobi@usesmileid.com' }
-  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.4.1" }
+  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.4.2" }
   s.ios.deployment_target = '13.0'
   s.dependency 'ZIPFoundation', '~> 0.9'
   s.dependency 'FingerprintJS'

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -389,6 +389,7 @@ public class SmileID {
         showAttribution: Bool = true,
         showInstructions: Bool = true,
         useStrictMode _: Bool = false,
+        skipApiSubmission : Bool = false,
         extraPartnerParams: [String: String] = [:],
         delegate: SmartSelfieResultDelegate
     ) -> some View {
@@ -401,7 +402,7 @@ public class SmileID {
             showAttribution: showAttribution,
             showInstructions: showInstructions,
             extraPartnerParams: extraPartnerParams,
-            skipApiSubmission: false,
+            skipApiSubmission: skipApiSubmission,
             onResult: delegate
         )
     }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -418,6 +418,7 @@ public class SmileID {
     ///   - showAttribution: Whether to show the Smile ID attribution or not on the Instructions
     ///     screen
     ///   - showInstructions: Whether to deactivate capture screen's instructions for SmartSelfie.
+    ///   - skipApiSubmission: Whether to skip api submission to SmileID and return only captured images
     ///   - extraPartnerParams: Custom values specific to partners
     ///   - delegate: Callback to be invoked when the SmartSelfie™ Authentication is complete.
     @ViewBuilder public class func smartSelfieAuthenticationScreenEnhanced(
@@ -425,6 +426,7 @@ public class SmileID {
         allowNewEnroll: Bool = false,
         showAttribution: Bool = true,
         showInstructions: Bool = true,
+        skipApiSubmission: Bool = false,
         extraPartnerParams: [String: String] = [:],
         delegate: SmartSelfieResultDelegate
     ) -> some View {
@@ -434,6 +436,7 @@ public class SmileID {
             allowNewEnroll: allowNewEnroll,
             showAttribution: showAttribution,
             showInstructions: showInstructions,
+            skipApiSubmission: skipApiSubmission,
             extraPartnerParams: extraPartnerParams,
             onResult: delegate
         )

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -6,7 +6,7 @@ import UIKit
 public class SmileID {
     /// The default value for `timeoutIntervalForRequest` for URLSession default configuration.
     public static let defaultRequestTimeout: TimeInterval = 60
-    public static let version = "10.4.1"
+    public static let version = "10.4.2"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
 
@@ -343,6 +343,7 @@ public class SmileID {
         allowNewEnroll: Bool = false,
         showAttribution: Bool = true,
         showInstructions: Bool = true,
+        skipApiSubmission: Bool = false,
         extraPartnerParams: [String: String] = [:],
         delegate: SmartSelfieResultDelegate
     ) -> some View {
@@ -352,6 +353,7 @@ public class SmileID {
             allowNewEnroll: allowNewEnroll,
             showAttribution: showAttribution,
             showInstructions: showInstructions,
+            skipApiSubmission: skipApiSubmission,
             extraPartnerParams: extraPartnerParams,
             onResult: delegate
         )

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -336,6 +336,7 @@ public class SmileID {
     ///   - showAttribution: Whether to show the Smile ID attribution or not on the Instructions
     ///     screen
     ///   - showInstructions: Whether to deactivate capture screen's instructions for SmartSelfie.
+    ///   - skipApiSubmission: Whether to skip api submission to SmileID and return only captured images
     ///   - extraPartnerParams: Custom values specific to partners
     ///   - delegate: Callback to be invoked when the SmartSelfie™ Enrollment is complete.
     @ViewBuilder public class func smartSelfieEnrollmentScreenEnhanced(

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -389,7 +389,7 @@ public class SmileID {
         showAttribution: Bool = true,
         showInstructions: Bool = true,
         useStrictMode _: Bool = false,
-        skipApiSubmission : Bool = false,
+        skipApiSubmission: Bool = false,
         extraPartnerParams: [String: String] = [:],
         delegate: SmartSelfieResultDelegate
     ) -> some View {
@@ -536,7 +536,8 @@ public class SmileID {
     ///   - showAttribution: Whether to show the Smile ID attribution on the Instructions screen
     ///   - skipApiSubmission: Whether to skip api submission to SmileID and return only captured images
     ///   - extraPartnerParams: Custom values specific to partners
-    ///  - consentInformation: Consent information based on when the user has accepted consent, if they have not the default will be false
+    ///  - consentInformation: Consent information based on when the user has
+    ///  accepted consent, if they have not the default will be false
     ///  and the timestamp will be at the point of screen being shown
     ///   - delegate: The delegate object that receives the result of the Document Verification
     public class func enhancedDocumentVerificationScreen(
@@ -621,7 +622,8 @@ public class SmileID {
     ///  - showInstructions: Whether to deactivate capture screen's instructions for SmartSelfie.
     ///  - skipApiSubmission: Whether to skip api submission to SmileID and return only captured images
     ///  - extraPartnerParams: Custom values specific to partners
-    ///  - consentInformation: Consent information based on when the user has accepted consent, if they have not the default will be false
+    ///  - consentInformation: Consent information based on when the user has accepted consent,
+    ///  if they have not the default will be false
     ///  and the timestamp will be at the point of screen being shown
     ///  - delegate: Callback to be invoked when the Biometric KYC is complete.
     public class func biometricKycScreen(


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/15242/enable-support-for-standalone-enhanced-smartselfie-for-all-sdks

## Summary

Skip Api submission functionality for selfie capture screens without enrollment

## Known Issues

N/A

## Test Instructions

* Run SmartSelfie™ enrollment capture flow without skipApiSubmission, job should be submitted
* Run SmartSelfie™ enrollment capture flow skipApiSubmission true , job should NOT be submitted
* Run Enhanced SmartSelfie™ enrollment capture flow without skipApiSubmission, job should be submitted
* Run Enhanced  SmartSelfie™ enrollment capture flow skipApiSubmission true , job should NOT be submitted

## Screenshot

N/A
