### PR TITLE
Fix/allow new enroll as bool

### DIFF
--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -178,7 +178,7 @@ class OrchestratedBiometricKycViewModel: ObservableObject {
     private func prepareForUpload(authResponse: AuthenticationResponse) async throws -> PrepUploadResponse {
         let prepUploadRequest = PrepUploadRequest(
             partnerParams: authResponse.partnerParams.copy(extras: extraPartnerParams),
-            allowNewEnroll: String(allowNewEnroll), // TODO: - Fix when Michael changes this to boolean
+            allowNewEnroll: allowNewEnroll,
             metadata: localMetadata.metadata.items,
             timestamp: authResponse.timestamp,
             signature: authResponse.signature

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -211,7 +211,7 @@ class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: ObservableObj
                 let authResponse = try await SmileID.api.authenticate(request: authRequest)
                 let prepUploadRequest = PrepUploadRequest(
                     partnerParams: authResponse.partnerParams.copy(extras: self.extraPartnerParams),
-                    allowNewEnroll: String(allowNewEnroll), // TODO: - Fix when Michael changes this to boolean
+                    allowNewEnroll: allowNewEnroll,
                     metadata: localMetadata.metadata.items,
                     timestamp: authResponse.timestamp,
                     signature: authResponse.signature

--- a/Sources/SmileID/Classes/Helpers/LocalStorage.swift
+++ b/Sources/SmileID/Classes/Helpers/LocalStorage.swift
@@ -193,7 +193,7 @@ public class LocalStorage {
                         jobType: jobType,
                         extras: partnerParams
                     ),
-                    allowNewEnroll: String(allowNewEnroll),
+                    allowNewEnroll: allowNewEnroll,
                     metadata: localMetadata.metadata.items,
                     timestamp: "", // remove this so it is not stored offline
                     signature: "" // remove this so it is not stored offline

--- a/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
+++ b/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
@@ -4,8 +4,7 @@ public struct PrepUploadRequest: Codable {
     public var partnerParams: PartnerParams
     // Callback URL *must* be defined either within your Partner Portal or here
     public var callbackUrl: String? = SmileID.callbackUrl
-    // TODO: - Michael will change this to a boolean
-    public var allowNewEnroll: String = "false"
+    public var allowNewEnroll: Bool = false
     public var partnerId = SmileID.config.partnerId
     public var metadata: [Metadatum]?
     public var sourceSdk = "ios"
@@ -18,7 +17,7 @@ public struct PrepUploadRequest: Codable {
     public init(
         partnerParams: PartnerParams,
         callbackUrl: String? = SmileID.callbackUrl,
-        allowNewEnroll: String = "false",
+        allowNewEnroll: Bool = false,
         partnerId: String = SmileID.config.partnerId,
         metadata: [Metadatum]? = nil,
         sourceSdk: String = "ios",

--- a/Sources/SmileID/Classes/Networking/ServiceRunnable.swift
+++ b/Sources/SmileID/Classes/Networking/ServiceRunnable.swift
@@ -308,8 +308,7 @@ extension ServiceRunnable {
 
         // Append allowNewEnroll if available
         if let allowNewEnroll = allowNewEnroll {
-            let allowNewEnrollString = "\(allowNewEnroll)"
-            if let valueData = "\(allowNewEnrollString)\(lineBreak)".data(using: .utf8) {
+            if let valueData = "\(allowNewEnroll)\(lineBreak)".data(using: .utf8) {
                 body.append("--\(boundary)\(lineBreak)".data(using: .utf8)!)
                 body.append(
                     "Content-Disposition: form-data; name=\"allow_new_enroll\"\(lineBreak + lineBreak)".data(

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -184,9 +184,9 @@ public class SmileID {
                 let authResponse = try await SmileID.api.authenticate(request: authRequest)
                 let prepUploadRequest = PrepUploadRequest(
                     partnerParams: authResponse.partnerParams.copy(
-                        extras: prepUploadFile.partnerParams.extras),
-                    // TODO: - Fix when Michael changes this to boolean
-                    allowNewEnroll: String(prepUploadFile.allowNewEnroll),
+                        extras: prepUploadFile.partnerParams.extras
+                    ),
+                    allowNewEnroll: prepUploadFile.allowNewEnroll,
                     timestamp: authResponse.timestamp,
                     signature: authResponse.signature
                 )

--- a/Sources/SmileID/Classes/Views/JobSubmittable.swift
+++ b/Sources/SmileID/Classes/Views/JobSubmittable.swift
@@ -24,7 +24,7 @@ extension JobSubmittable {
     ) async throws -> PrepUploadResponse {
         let prepUploadRequest = PrepUploadRequest(
             partnerParams: authResponse.partnerParams.copy(extras: extraPartnerParams),
-            allowNewEnroll: String(allowNewEnroll), // TODO - Fix when Michael changes this to boolean
+            allowNewEnroll: allowNewEnroll,
             timestamp: authResponse.timestamp,
             signature: authResponse.signature
         )


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

This PR changes the `allow_new_enroll` flag that is sent in the prepupload `/upload` and in the multi-part upload requests. It also changes the way how we store the prepUpload request in case of offline mode and this is a breaking change in case someone has a job stored and updates the app inbetween.

## Known Issues
Breaking change in case of stored offline job.

## Test Instructions
Run a biometric kyc job or a selfie enrollment job and check if the flag is a bool instead of a string.

## Screenshot
-
