### PR TITLE
Fix Error Callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 10.5.1
+
+### Fixed
+* Selfie submission error returned in success delegate callback.
+
 ## 10.5.0
 
 * Update lottie-ios to minimum `v4.5.0`

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,7 +4,7 @@ platform :ios, '13.0'
 target 'SmileID_Example' do
   pod 'SmileID', :path => '../'
   pod 'netfox'
-  pod 'Sentry', '~> 8.43.0'
+  pod 'Sentry', '~> 8.48.0'
   pod 'SwiftLint'
   pod 'ArkanaKeys', :path => './ArkanaKeys/ArkanaKeys/'
   pod 'ArkanaKeysInterfaces', :path => './ArkanaKeys/ArkanaKeysInterfaces/'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,9 +9,9 @@ PODS:
   - FingerprintJS/SystemControl (1.5.0)
   - lottie-ios (4.5.1)
   - netfox (1.21.0)
-  - Sentry (8.43.0):
-    - Sentry/Core (= 8.43.0)
-  - Sentry/Core (8.43.0)
+  - Sentry (8.48.0):
+    - Sentry/Core (= 8.48.0)
+  - Sentry/Core (8.48.0)
   - SmileID (10.5.0):
     - FingerprintJS
     - lottie-ios (~> 4.5.0)
@@ -23,7 +23,7 @@ DEPENDENCIES:
   - ArkanaKeys (from `./ArkanaKeys/ArkanaKeys/`)
   - ArkanaKeysInterfaces (from `./ArkanaKeys/ArkanaKeysInterfaces/`)
   - netfox
-  - Sentry (~> 8.43.0)
+  - Sentry (~> 8.48.0)
   - SmileID (from `../`)
   - SwiftLint
 
@@ -50,11 +50,11 @@ SPEC CHECKSUMS:
   FingerprintJS: 96410117a394cca04d0f1e2374944c8697f2cceb
   lottie-ios: 248b380fa1b97d18e792c37d90da7ab2aa0d6562
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
-  Sentry: 532b281a53b1b45a523fd592f608956fb36e577c
+  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
   SmileID: eab70b212dcc89e5614035e1746016db172c8f50
   SwiftLint: 365bcd9ffc83d0deb874e833556d82549919d6cd
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 3d594b06532c72adf95b06a33b17603190f6e8bb
+PODFILE CHECKSUM: 0aff99f038f933ca54faf251acd82e30dc5acf1b
 
 COCOAPODS: 1.16.2

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - Sentry (8.48.0):
     - Sentry/Core (= 8.48.0)
   - Sentry/Core (8.48.0)
-  - SmileID (10.5.0):
+  - SmileID (10.5.1):
     - FingerprintJS
     - lottie-ios (~> 4.5.0)
     - ZIPFoundation (~> 0.9)
@@ -51,7 +51,7 @@ SPEC CHECKSUMS:
   lottie-ios: 248b380fa1b97d18e792c37d90da7ab2aa0d6562
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
   Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
-  SmileID: eab70b212dcc89e5614035e1746016db172c8f50
+  SmileID: 7f9c9db916d4c3997fcafb8b811afec30e88c751
   SwiftLint: 365bcd9ffc83d0deb874e833556d82549919d6cd
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 

--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 		91D9FBC32AB481FE00A8D36B /* PollingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingTests.swift; sourceTree = "<group>"; };
 		91D9FBD42AB8AB4700A8D36B /* CalculateSignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateSignatureTests.swift; sourceTree = "<group>"; };
 		94E7560A47E255DD8215C183 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		9755B6A19CF28DE212F24C83 /* SmileID.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SmileID.podspec; path = ../SmileID.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9755B6A19CF28DE212F24C83 /* SmileID.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SmileID.podspec; path = ../SmileID.podspec; sourceTree = "<group>"; };
 		C33E410576AADC1679867B4C /* Pods-SmileID_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SmileID_Example.debug.xcconfig"; path = "Target Support Files/Pods-SmileID_Example/Pods-SmileID_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		C8CD2E3DB817D8C6334E9240 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		CB9672F4E61EFD2E0BE586D2 /* Pods_SmileID_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SmileID_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '10.5.0'
+  s.version          = '10.5.1'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/ios-v10-beta'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Japhet' => 'japhet@usesmileid.com', 'Juma Allan' => 'juma@usesmileid.com', 'Vansh Gandhi' => 'vansh@usesmileid.com', 'Tobi Omotayo' => 'oluwatobi@usesmileid.com' }
-  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.5.0" }
+  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.5.1" }
   s.ios.deployment_target = '13.0'
   s.dependency 'ZIPFoundation', '~> 0.9'
   s.dependency 'FingerprintJS'

--- a/Sources/SmileID/Classes/SelfieCapture/EnhancedSmartSelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/EnhancedSmartSelfieViewModel.swift
@@ -541,12 +541,13 @@ extension EnhancedSmartSelfieViewModel: SelfieSubmissionDelegate {
     }
 
     public func onFinished(callback: SmartSelfieResultDelegate) {
-        if let selfieImageURL = selfieImageURL,
+        if let error = self.error {
+            callback.didError(error: error)
+        } else if let selfieImageURL = selfieImageURL,
            let selfiePath = getRelativePath(from: selfieImageURL),
            livenessImages.count == numLivenessImages,
            !livenessImages.contains(where: { getRelativePath(from: $0) == nil }
-           )
-        {
+           ) {
             let livenessImagesPaths = livenessImages.compactMap {
                 getRelativePath(from: $0)
             }
@@ -556,8 +557,6 @@ extension EnhancedSmartSelfieViewModel: SelfieSubmissionDelegate {
                 livenessImages: livenessImagesPaths,
                 apiResponse: apiResponse
             )
-        } else if let error = error {
-            callback.didError(error: error)
         }
     }
 

--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -546,12 +546,13 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
     }
 
     public func onFinished(callback: SmartSelfieResultDelegate) {
-        if let selfieImage = selfieImage,
+        if let error = self.error {
+            callback.didError(error: error)
+        } else if let selfieImage = selfieImage,
             let selfiePath = getRelativePath(from: selfieImage),
             livenessImages.count == numLivenessImages,
             !livenessImages.contains(where: { getRelativePath(from: $0) == nil }
-            )
-        {
+            ) {
             let livenessImagesPaths = livenessImages.compactMap {
                 getRelativePath(from: $0)
             }
@@ -561,8 +562,6 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
                 livenessImages: livenessImagesPaths,
                 apiResponse: apiResponse
             )
-        } else if let error = error {
-            callback.didError(error: error)
         } else {
             callback.didError(error: SmileIDError.unknown("Unknown error"))
         }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -213,7 +213,7 @@ public class SmileID {
                         LocalStorage.getFileByType(jobId: jobId, fileType: .selfie),
                         LocalStorage.getFileByType(jobId: jobId, fileType: .documentFront),
                         LocalStorage.getFileByType(jobId: jobId, fileType: .documentBack),
-                        LocalStorage.getInfoJsonFile(jobId: jobId),
+                        LocalStorage.getInfoJsonFile(jobId: jobId)
                     ].compactMap { $0 }
                     allFiles = livenessFiles + additionalFiles
                 } catch {

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -6,7 +6,7 @@ import UIKit
 public class SmileID {
     /// The default value for `timeoutIntervalForRequest` for URLSession default configuration.
     public static let defaultRequestTimeout: TimeInterval = 60
-    public static let version = "10.5.0"
+    public static let version = "10.5.1"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
 


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/15468/fix-inconsistent-error-callback-route-in-flutter-sdk

## Summary

* Prioritise error check before liveness and selfie images in onFinished method of SelfieViewModel.
* Prepare version number and changelog for release.

## Known Issues

N/A.

## Test Instructions

* Start a Selfie authentication job and enter a random user id
* After completing selfie capture - it should fail to submit with error "no enrolled user"
* Tap close button and check that the didError callback is called instead of didSucceed in HomeViewModel or any object that conforms to `SmartSelfieResultDelegate`.

## Screenshot

N/A.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix error callback priority in SelfieViewModel

- Update version to 10.5.1

- Update Sentry dependency

- Add changelog entry


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelfieViewModel.swift</strong><dd><code>Prioritize error handling in onFinished method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift

<li>Reordered conditional checks to prioritize error checking before <br>liveness and selfie image validation<br> <li> Moved error check to the beginning of the onFinished method<br> <li> Removed redundant error check that was previously positioned after <br>success path


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/311/files#diff-ce09d5beb9fce2c0797ee811714d6123d4694f641aec1bdaa5cfa9447eee3369">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SmileID.swift</strong><dd><code>Bump version number to 10.5.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/SmileID.swift

- Updated version number from 10.5.0 to 10.5.1


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/311/files#diff-f3d68c54e1ada0e2583305e0eae8f50274fe9e6d418d4faa2b4337c04b49285a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileID.podspec</strong><dd><code>Update podspec version to 10.5.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileID.podspec

<li>Updated version number from 10.5.0 to 10.5.1 in multiple places<br> <li> Updated git tag reference to v10.5.1


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/311/files#diff-7b77f15ea198e0bc969823c4cfbc250e2f35c075d092f421f4bffc86d00973a4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for version 10.5.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entry for version 10.5.1<br> <li> Documented the bug fix for selfie submission error being returned in <br>success delegate callback


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/311/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Podfile</strong><dd><code>Update Sentry dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Example/Podfile

- Updated Sentry dependency from ~> 8.43.0 to ~> 8.48.0


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/311/files#diff-29b5a1cbec50129afcbbcdb6f92d1ba7d2691f19e2fa6716590dda60134413df">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.pbxproj</strong><dd><code>Remove language specification for podspec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Example/SmileID.xcodeproj/project.pbxproj

<li>Removed xcLanguageSpecificationIdentifier attribute for <br>SmileID.podspec file reference


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/311/files#diff-88aa08ea238e57c3aa39fc93020b1e6185753c61d5413447ba6fb867b4cbe5fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>