### PR TITLE
Fix/retry as bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* Changes the `retry` flag to be a boolean instead of a string for prepUpload requests. This is a breaking change for stored offline jobs, where the job is written using an older sdk version and then submission is attempted using this version
+
 ## 10.5.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 10.5.1
+
+### Fixed
+* Selfie submission error returned in success delegate callback.
+
 ## 10.5.0
 
 * Update lottie-ios to minimum `v4.5.0`

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,7 +4,7 @@ platform :ios, '13.0'
 target 'SmileID_Example' do
   pod 'SmileID', :path => '../'
   pod 'netfox'
-  pod 'Sentry', '~> 8.43.0'
+  pod 'Sentry', '~> 8.48.0'
   pod 'SwiftLint'
   pod 'ArkanaKeys', :path => './ArkanaKeys/ArkanaKeys/'
   pod 'ArkanaKeysInterfaces', :path => './ArkanaKeys/ArkanaKeysInterfaces/'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,10 +9,10 @@ PODS:
   - FingerprintJS/SystemControl (1.5.0)
   - lottie-ios (4.5.1)
   - netfox (1.21.0)
-  - Sentry (8.43.0):
-    - Sentry/Core (= 8.43.0)
-  - Sentry/Core (8.43.0)
-  - SmileID (10.5.0):
+  - Sentry (8.48.0):
+    - Sentry/Core (= 8.48.0)
+  - Sentry/Core (8.48.0)
+  - SmileID (10.5.1):
     - FingerprintJS
     - lottie-ios (~> 4.5.0)
     - ZIPFoundation (~> 0.9)
@@ -23,7 +23,7 @@ DEPENDENCIES:
   - ArkanaKeys (from `./ArkanaKeys/ArkanaKeys/`)
   - ArkanaKeysInterfaces (from `./ArkanaKeys/ArkanaKeysInterfaces/`)
   - netfox
-  - Sentry (~> 8.43.0)
+  - Sentry (~> 8.48.0)
   - SmileID (from `../`)
   - SwiftLint
 
@@ -50,11 +50,11 @@ SPEC CHECKSUMS:
   FingerprintJS: 96410117a394cca04d0f1e2374944c8697f2cceb
   lottie-ios: 248b380fa1b97d18e792c37d90da7ab2aa0d6562
   netfox: 9d5cc727fe7576c4c7688a2504618a156b7d44b7
-  Sentry: 532b281a53b1b45a523fd592f608956fb36e577c
-  SmileID: eab70b212dcc89e5614035e1746016db172c8f50
+  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
+  SmileID: 7f9c9db916d4c3997fcafb8b811afec30e88c751
   SwiftLint: 365bcd9ffc83d0deb874e833556d82549919d6cd
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 3d594b06532c72adf95b06a33b17603190f6e8bb
+PODFILE CHECKSUM: 0aff99f038f933ca54faf251acd82e30dc5acf1b
 
 COCOAPODS: 1.16.2

--- a/Example/SmileID.xcodeproj/project.pbxproj
+++ b/Example/SmileID.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 		91D9FBC32AB481FE00A8D36B /* PollingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingTests.swift; sourceTree = "<group>"; };
 		91D9FBD42AB8AB4700A8D36B /* CalculateSignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateSignatureTests.swift; sourceTree = "<group>"; };
 		94E7560A47E255DD8215C183 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		9755B6A19CF28DE212F24C83 /* SmileID.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SmileID.podspec; path = ../SmileID.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9755B6A19CF28DE212F24C83 /* SmileID.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SmileID.podspec; path = ../SmileID.podspec; sourceTree = "<group>"; };
 		C33E410576AADC1679867B4C /* Pods-SmileID_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SmileID_Example.debug.xcconfig"; path = "Target Support Files/Pods-SmileID_Example/Pods-SmileID_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		C8CD2E3DB817D8C6334E9240 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		CB9672F4E61EFD2E0BE586D2 /* Pods_SmileID_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SmileID_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '10.5.0'
+  s.version          = '10.5.1'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/ios-v10-beta'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Japhet' => 'japhet@usesmileid.com', 'Juma Allan' => 'juma@usesmileid.com', 'Vansh Gandhi' => 'vansh@usesmileid.com', 'Tobi Omotayo' => 'oluwatobi@usesmileid.com' }
-  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.5.0" }
+  s.source           = { :git => "https://github.com/smileidentity/ios.git", :tag => "v10.5.1" }
   s.ios.deployment_target = '13.0'
   s.dependency 'ZIPFoundation', '~> 0.9'
   s.dependency 'FingerprintJS'

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -176,7 +176,7 @@ class OrchestratedBiometricKycViewModel: ObservableObject {
     }
 
     private func prepareForUpload(authResponse: AuthenticationResponse) async throws -> PrepUploadResponse {
-        let prepUploadRequest = PrepUploadRequest(
+        var prepUploadRequest = PrepUploadRequest(
             partnerParams: authResponse.partnerParams.copy(extras: extraPartnerParams),
             allowNewEnroll: allowNewEnroll,
             metadata: localMetadata.metadata.items,
@@ -193,8 +193,10 @@ class OrchestratedBiometricKycViewModel: ObservableObject {
             else {
                 throw error
             }
+            prepUploadRequest.retry = true
             return try await SmileID.api.prepUpload(
-                request: prepUploadRequest.copy(retry: "true"))
+                request: prepUploadRequest
+            )
         }
     }
 

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -209,7 +209,7 @@ class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: ObservableObj
                     )
                 }
                 let authResponse = try await SmileID.api.authenticate(request: authRequest)
-                let prepUploadRequest = PrepUploadRequest(
+                var prepUploadRequest = PrepUploadRequest(
                     partnerParams: authResponse.partnerParams.copy(extras: self.extraPartnerParams),
                     allowNewEnroll: allowNewEnroll,
                     metadata: localMetadata.metadata.items,
@@ -224,8 +224,9 @@ class IOrchestratedDocumentVerificationViewModel<T, U: JobResult>: ObservableObj
                 } catch let error as SmileIDError {
                     switch error {
                     case .api("2215", _):
+                        prepUploadRequest.retry = true
                         prepUploadResponse = try await SmileID.api.prepUpload(
-                            request: prepUploadRequest.copy(retry: "true")
+                            request: prepUploadRequest
                         )
                     default:
                         throw error

--- a/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
+++ b/Sources/SmileID/Classes/Networking/Models/PrepUpload.swift
@@ -12,7 +12,7 @@ public struct PrepUploadRequest: Codable {
     public var timestamp = Date().toISO8601WithMilliseconds()
     public var signature = ""
     public var useEnrolledImage = false
-    public var retry = "false" /// backend is broken needs these as strings
+    public var retry: Bool = false
 
     public init(
         partnerParams: PartnerParams,
@@ -25,7 +25,7 @@ public struct PrepUploadRequest: Codable {
         timestamp: String = Date().toISO8601WithMilliseconds(),
         signature: String = "",
         useEnrolledImage: Bool = false,
-        retry: String = "false"
+        retry: Bool = false
     ) {
         self.partnerParams = partnerParams
         self.callbackUrl = callbackUrl
@@ -52,22 +52,6 @@ public struct PrepUploadRequest: Codable {
         case signature
         case retry
         case metadata
-    }
-
-    public func copy(retry: String? = nil) -> PrepUploadRequest {
-        return PrepUploadRequest(
-            partnerParams: partnerParams,
-            callbackUrl: callbackUrl,
-            allowNewEnroll: allowNewEnroll,
-            partnerId: partnerId,
-            metadata: metadata,
-            sourceSdk: sourceSdk,
-            sourceSdkVersion: sourceSdkVersion,
-            timestamp: timestamp,
-            signature: signature,
-            useEnrolledImage: useEnrolledImage,
-            retry: retry ?? self.retry
-        )
     }
 }
 

--- a/Sources/SmileID/Classes/SelfieCapture/EnhancedSmartSelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/EnhancedSmartSelfieViewModel.swift
@@ -541,12 +541,13 @@ extension EnhancedSmartSelfieViewModel: SelfieSubmissionDelegate {
     }
 
     public func onFinished(callback: SmartSelfieResultDelegate) {
-        if let selfieImageURL = selfieImageURL,
+        if let error = self.error {
+            callback.didError(error: error)
+        } else if let selfieImageURL = selfieImageURL,
            let selfiePath = getRelativePath(from: selfieImageURL),
            livenessImages.count == numLivenessImages,
            !livenessImages.contains(where: { getRelativePath(from: $0) == nil }
-           )
-        {
+           ) {
             let livenessImagesPaths = livenessImages.compactMap {
                 getRelativePath(from: $0)
             }
@@ -556,8 +557,6 @@ extension EnhancedSmartSelfieViewModel: SelfieSubmissionDelegate {
                 livenessImages: livenessImagesPaths,
                 apiResponse: apiResponse
             )
-        } else if let error = error {
-            callback.didError(error: error)
         }
     }
 

--- a/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/SelfieViewModel.swift
@@ -546,12 +546,13 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
     }
 
     public func onFinished(callback: SmartSelfieResultDelegate) {
-        if let selfieImage = selfieImage,
+        if let error = self.error {
+            callback.didError(error: error)
+        } else if let selfieImage = selfieImage,
             let selfiePath = getRelativePath(from: selfieImage),
             livenessImages.count == numLivenessImages,
             !livenessImages.contains(where: { getRelativePath(from: $0) == nil }
-            )
-        {
+            ) {
             let livenessImagesPaths = livenessImages.compactMap {
                 getRelativePath(from: $0)
             }
@@ -561,8 +562,6 @@ public class SelfieViewModel: ObservableObject, ARKitSmileDelegate {
                 livenessImages: livenessImagesPaths,
                 apiResponse: apiResponse
             )
-        } else if let error = error {
-            callback.didError(error: error)
         } else {
             callback.didError(error: SmileIDError.unknown("Unknown error"))
         }

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -6,7 +6,7 @@ import UIKit
 public class SmileID {
     /// The default value for `timeoutIntervalForRequest` for URLSession default configuration.
     public static let defaultRequestTimeout: TimeInterval = 60
-    public static let version = "10.5.0"
+    public static let version = "10.5.1"
     @Injected var injectedApi: SmileIDServiceable
     public static var configuration: Config { config }
 
@@ -213,7 +213,7 @@ public class SmileID {
                         LocalStorage.getFileByType(jobId: jobId, fileType: .selfie),
                         LocalStorage.getFileByType(jobId: jobId, fileType: .documentFront),
                         LocalStorage.getFileByType(jobId: jobId, fileType: .documentBack),
-                        LocalStorage.getInfoJsonFile(jobId: jobId),
+                        LocalStorage.getInfoJsonFile(jobId: jobId)
                     ].compactMap { $0 }
                     allFiles = livenessFiles + additionalFiles
                 } catch {

--- a/Sources/SmileID/Classes/SmileID.swift
+++ b/Sources/SmileID/Classes/SmileID.swift
@@ -182,7 +182,7 @@ public class SmileID {
                     userId: authRequestFile.userId
                 )
                 let authResponse = try await SmileID.api.authenticate(request: authRequest)
-                let prepUploadRequest = PrepUploadRequest(
+                var prepUploadRequest = PrepUploadRequest(
                     partnerParams: authResponse.partnerParams.copy(
                         extras: prepUploadFile.partnerParams.extras
                     ),
@@ -198,8 +198,9 @@ public class SmileID {
                 } catch let error as SmileIDError {
                     switch error {
                     case .api("2215", _):
+                        prepUploadRequest.retry = true
                         prepUploadResponse = try await SmileID.api.prepUpload(
-                            request: prepUploadRequest.copy(retry: "true")
+                            request: prepUploadRequest
                         )
                     default:
                         throw error


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

Fixes the `retry` flag to be a bool instead of a string. The backend supports this and android sends it as a bool as well. It is also needed for the payload signing to use it as a bool.

## Known Issues
-

## Test Instructions
Test biometric kyc, docv, enhanced docv to check if it has the correct params.

## Screenshot
-


___

### **PR Type**
Bug fix


___

### **Description**
- Change retry flag from string to boolean

- Update API calls to use boolean retry flag

- Fix error handling for API error code 2215

- Add changelog entry for breaking change


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OrchestratedBiometricKycViewModel.swift</strong><dd><code>Update retry handling in BiometricKYC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift

<li>Changed <code>prepUploadRequest</code> from constant to variable<br> <li> Set <code>retry = true</code> directly on the request object<br> <li> Removed call to <code>copy()</code> method with retry parameter<br> <li> Updated API call to use modified request object


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/312/files#diff-f2d3970bebf4a742e771bdaada48824d032569744a09fb76f7cddad4c3dcdcba">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OrchestratedDocumentVerificationViewModel.swift</strong><dd><code>Update retry handling in DocumentVerification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift

<li>Changed <code>prepUploadRequest</code> from constant to variable<br> <li> Set <code>retry = true</code> directly on the request object<br> <li> Removed call to <code>copy()</code> method with retry parameter<br> <li> Updated API call to use modified request object


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/312/files#diff-21446c9903139b4f0be2f382b7ff7eb5f726cfbacca392ed231176a1a95a6ad6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PrepUpload.swift</strong><dd><code>Change retry type from String to Bool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/Networking/Models/PrepUpload.swift

<li>Changed <code>retry</code> property type from <code>String</code> to <code>Bool</code><br> <li> Updated default value from <code>"false"</code> to <code>false</code><br> <li> Removed comment about backend requiring strings<br> <li> Removed <code>copy()</code> method as it's no longer needed


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/312/files#diff-bbce838ffff642dcb6f4dd34732fb7c681df6aee831469a87071e54cea96ffc8">+2/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileID.swift</strong><dd><code>Update retry handling in SmileID class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/SmileID.swift

<li>Changed <code>prepUploadRequest</code> from constant to variable<br> <li> Set <code>retry = true</code> directly on the request object<br> <li> Removed call to <code>copy()</code> method with retry parameter<br> <li> Updated API call to use modified request object


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/312/files#diff-f3d68c54e1ada0e2583305e0eae8f50274fe9e6d418d4faa2b4337c04b49285a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document breaking change in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entry for unreleased changes<br> <li> Documented the breaking change for stored offline jobs


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/312/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>