### PR TITLE
Require re-capture when retrying failed submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## [Unreleased]
+
+### Changed
+* Require selfie recapture when retrying failed submission for Enhanced Smart Selfie Capture.
+
 ## 10.5.1
 
 ### Fixed

--- a/Sources/SmileID/Classes/FaceDetector/LivenessCheckManager.swift
+++ b/Sources/SmileID/Classes/FaceDetector/LivenessCheckManager.swift
@@ -106,6 +106,7 @@ class LivenessCheckManager: ObservableObject {
     private func handleTaskTimeout() {
         stopTaskTimer()
         delegate?.livenessChallengeTimeout()
+        resetLivenessChallenge()
     }
 
     /// Advances to the next task in the sequence
@@ -122,6 +123,14 @@ class LivenessCheckManager: ObservableObject {
     /// Sets the initial task for the liveness check.
     func initiateLivenessCheck() {
         currentTask = livenessTaskSequence[currentTaskIndex]
+    }
+
+    private func resetLivenessChallenge() {
+        currentTask = nil
+        currentTaskIndex = 0
+        lookLeftProgress = 0
+        lookRightProgress = 0
+        lookUpProgress = 0
     }
 
     /// Processes face geometry data and checks for task completion
@@ -182,7 +191,7 @@ class LivenessCheckManager: ObservableObject {
         if !advanceToNextTask() {
             // Liveness challenge complete
             delegate?.didCompleteLivenessChallenge()
-            self.currentTask = nil
+            resetLivenessChallenge()
         }
     }
 }

--- a/Sources/SmileID/Classes/SelfieCapture/EnhancedSmartSelfieViewModel.swift
+++ b/Sources/SmileID/Classes/SelfieCapture/EnhancedSmartSelfieViewModel.swift
@@ -135,6 +135,7 @@ public class EnhancedSmartSelfieViewModel: ObservableObject {
                 with: livenessCheckManager.$lookRightProgress,
                 livenessCheckManager.$lookUpProgress
             )
+            .filter { $0 != 0 }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 DispatchQueue.main.async {
@@ -217,7 +218,7 @@ public class EnhancedSmartSelfieViewModel: ObservableObject {
         case .cancelSelfieCapture:
             handleCancelSelfieCapture()
         case .retryJobSubmission:
-            handleSubmission()
+            handleViewAppeared()
         case .openApplicationSettings:
             openSettings()
         case let .handleError(error):


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

* Reset selfie capture state when users hit retry
* Reset the state of liveness challenge.

## Known Issues

N/A

## Test Instructions

* Run a Smart Selfie Authentication Enhanced product without enrolling a user. 
* You should get an error that the user has not been enrolled
* Tap Retry button. You should have to recapture selfie before you can re-submit again.

## Screenshot

N/A


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reset selfie capture state on retry

- Reset liveness challenge state after completion

- Filter zero progress values in liveness check

- Fix retry flow to recapture selfie


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LivenessCheckManager.swift</strong><dd><code>Add liveness challenge state reset functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/FaceDetector/LivenessCheckManager.swift

<li>Added new <code>resetLivenessChallenge()</code> method to reset all state variables<br> <li> Call reset method on timeout to clear state<br> <li> Replace direct state reset with the new reset method after challenge <br>completion


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/314/files#diff-605f8269c788f1b636703fba214d87fd65a3ee9bd9aed81b22280ace81f8f1d0">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EnhancedSmartSelfieViewModel.swift</strong><dd><code>Fix retry flow to require selfie recapture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/SelfieCapture/EnhancedSmartSelfieViewModel.swift

<li>Added filter to ignore zero progress values in liveness check<br> <li> Changed retry behavior to call <code>handleViewAppeared()</code> instead of <br><code>handleSubmission()</code>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/314/files#diff-72f9bb5deaeb7c97fd27a481ca9e4fdf2352d7e6dd9413c3e08c0e9df4b8aa90">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>