### PR TITLE
Fix onFinished Error Callback Order

### DIFF
--- a/Example/SmileID/EnhancedKYC/EnhancedKycWithIdInputScreenViewModel.swift
+++ b/Example/SmileID/EnhancedKYC/EnhancedKycWithIdInputScreenViewModel.swift
@@ -182,10 +182,10 @@ class EnhancedKycWithIdInputScreenViewModel: ObservableObject {
     }
 
     func onFinished(delegate: EnhancedKycResultDelegate) {
-        if let enhancedKycResponse = enhancedKycResponse {
-            delegate.didSucceed(enhancedKycResponse: enhancedKycResponse)
-        } else if let error = error {
+        if let error = error {
             delegate.didError(error: error)
+        } else if let enhancedKycResponse = enhancedKycResponse {
+            delegate.didSucceed(enhancedKycResponse: enhancedKycResponse)
         }
     }
 }

--- a/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
+++ b/Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift
@@ -61,17 +61,16 @@ class OrchestratedBiometricKycViewModel: ObservableObject {
     }
 
     func onFinished(delegate: BiometricKycResultDelegate) {
-        if let selfieFile = selfieFile,
+        if let error {
+            delegate.didError(error: error)
+        } else if let selfieFile = selfieFile,
            let livenessFiles = livenessFiles,
-           let selfiePath = getRelativePath(from: selfieFile)
-        {
+           let selfiePath = getRelativePath(from: selfieFile) {
             delegate.didSucceed(
                 selfieImage: selfiePath,
                 livenessImages: livenessFiles.compactMap { getRelativePath(from: $0) },
                 didSubmitBiometricJob: didSubmitBiometricJob
             )
-        } else if let error {
-            delegate.didError(error: error)
         } else {
             delegate.didError(error: SmileIDError.unknown("onFinish with no result or error"))
         }

--- a/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
+++ b/Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift
@@ -350,10 +350,11 @@ class OrchestratedDocumentVerificationViewModel:
     IOrchestratedDocumentVerificationViewModel<DocumentVerificationResultDelegate, DocumentVerificationJobResult>
 {
     override func onFinished(delegate: DocumentVerificationResultDelegate) {
-        if let savedFiles,
+        if let error {
+            delegate.didError(error: error)
+        } else if let savedFiles,
            let selfiePath = getRelativePath(from: selfieFile),
-           let documentFrontPath = getRelativePath(from: savedFiles.documentFront)
-        {
+           let documentFrontPath = getRelativePath(from: savedFiles.documentFront) {
             let documentBackPath = getRelativePath(from: savedFiles.documentBack)
             delegate.didSucceed(
                 selfie: selfiePath,
@@ -361,10 +362,6 @@ class OrchestratedDocumentVerificationViewModel:
                 documentBackImage: documentBackPath,
                 didSubmitDocumentVerificationJob: didSubmitJob
             )
-        } else if let error {
-            // We check error as the 2nd case because as long as jobStatusResponse is not nil, it
-            // was a success
-            delegate.didError(error: error)
         } else {
             delegate.didError(error: SmileIDError.unknown("Unknown error"))
         }
@@ -378,10 +375,11 @@ class OrchestratedEnhancedDocumentVerificationViewModel:
     >
 {
     override func onFinished(delegate: EnhancedDocumentVerificationResultDelegate) {
-        if let savedFiles,
+        if let error {
+            delegate.didError(error: error)
+        } else if let savedFiles,
            let selfiePath = getRelativePath(from: selfieFile),
-           let documentFrontPath = getRelativePath(from: savedFiles.documentFront)
-        {
+           let documentFrontPath = getRelativePath(from: savedFiles.documentFront) {
             let documentBackPath = getRelativePath(from: savedFiles.documentBack)
             delegate.didSucceed(
                 selfie: selfiePath,
@@ -389,10 +387,6 @@ class OrchestratedEnhancedDocumentVerificationViewModel:
                 documentBackImage: documentBackPath,
                 didSubmitEnhancedDocVJob: didSubmitJob
             )
-        } else if let error {
-            // We check error as the 2nd case because as long as jobStatusResponse is not nil, it
-            // was a success
-            delegate.didError(error: error)
         } else {
             delegate.didError(error: SmileIDError.unknown("Unknown error"))
         }


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/15468/

## Summary

* Prioritise checking for error first and sending error event before checking to send success event.

## Known Issues

N/A.

## Test Instructions

* You can simulate an error scenario by entering gibberish for the pre upload signature for Biometric KYC and Document Verification jobs:
* When an error happens during submission, click cancel and the screen should be dismissed with the didError delegate callback as opposed to the didSucceed delegate method.

## Screenshot

N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Prioritize error checking in callback order

- Fix error handling in BiometricKYC and DocumentVerification

- Ensure errors are reported before success checks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OrchestratedBiometricKycViewModel.swift</strong><dd><code>Prioritize error checking in BiometricKYC callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/BiometricKYC/OrchestratedBiometricKycViewModel.swift

<li>Reordered conditional checks in <code>onFinished</code> method to check for errors <br>first<br> <li> Moved error handling from second condition to first condition<br> <li> Ensures error callbacks are prioritized over success callbacks


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/319/files#diff-f2d3970bebf4a742e771bdaada48824d032569744a09fb76f7cddad4c3dcdcba">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OrchestratedDocumentVerificationViewModel.swift</strong><dd><code>Fix error handling order in DocumentVerification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/DocumentVerification/Model/OrchestratedDocumentVerificationViewModel.swift

<li>Reordered conditional checks in both <br><code>OrchestratedDocumentVerificationViewModel</code> and <br><code>OrchestratedEnhancedDocumentVerificationViewModel</code> classes<br> <li> Moved error handling to be checked first in both implementations<br> <li> Removed outdated comments about checking error as second case


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/319/files#diff-21446c9903139b4f0be2f382b7ff7eb5f726cfbacca392ed231176a1a95a6ad6">+8/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>