### PR TITLE
Fix Device Orientation Metadata, Use native ISODateFormatter.

### DIFF
--- a/Sources/SmileID/Classes/Helpers/DateUtils.swift
+++ b/Sources/SmileID/Classes/Helpers/DateUtils.swift
@@ -6,14 +6,9 @@ extension Date {
     public func toISO8601WithMilliseconds(
         timezone: TimeZone? = TimeZone(abbreviation: "UTC")
     ) -> String {
-        let formatter = DateFormatter()
-        /*
-        For UTC timezone the pattern adds 'Z' at the end of the string. For any other timezone the
-        pattern adds the timezone offset in format +hh:mm or -hh:mm.
-         */
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+        let formatter = ISO8601DateFormatter()
         formatter.timeZone = timezone
-        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter.string(from: self)
     }
 }

--- a/Sources/SmileID/Classes/Metadata/Providers/DeviceOrientationMetadata.swift
+++ b/Sources/SmileID/Classes/Metadata/Providers/DeviceOrientationMetadata.swift
@@ -35,6 +35,8 @@ class DeviceOrientationMetadata: MetadataProtocol {
             return
         }
         isRecordingDeviceOrientations = true
+        // Clear previous orientation history to start fresh recording session
+        deviceOrientations.removeAll()
 
         motionManager.accelerometerUpdateInterval = 0.5
         motionManager.startAccelerometerUpdates(to: OperationQueue.main) { [weak self] data, _ in
@@ -78,9 +80,6 @@ class DeviceOrientationMetadata: MetadataProtocol {
 
     func collectMetadata() -> [Metadatum] {
         stopRecordingDeviceOrientations()
-
-        // Ensure we clean up the device orientations always at the end, regardless of early returns
-        defer { deviceOrientations.removeAll() }
 
         return deviceOrientations.map {
             Metadatum(


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/15152/

## Summary

* Move clearing of device orientation data to the point where we start recording the data.
* use native ISODateFormatter for timestamps.

## Known Issues

N/A

## Test Instructions

* Run Selfie related jobs and you should now see device orientation data as part of metadata payload.
* Timestamps should also be in the correct format

## Screenshot

N/A


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix device orientation data clearing timing

- Use native ISO8601DateFormatter for timestamps

- Ensure orientation data persists in metadata payload

- Improve date formatting with fractional seconds


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateUtils.swift</strong><dd><code>Replace DateFormatter with ISO8601DateFormatter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/Helpers/DateUtils.swift

<li>Replaced custom DateFormatter with native ISO8601DateFormatter<br> <li> Simplified code by using formatOptions instead of dateFormat<br> <li> Added fractional seconds support with .withFractionalSeconds option<br> <li> Removed unnecessary locale setting


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/330/files#diff-2aa46ba9e4d42d960813505f046f044c686e87fb9416534118e55fb4b7f1bde9">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DeviceOrientationMetadata.swift</strong><dd><code>Fix timing of device orientation data clearing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SmileID/Classes/Metadata/Providers/DeviceOrientationMetadata.swift

<li>Moved device orientation clearing to the start of recording session<br> <li> Removed the defer block that was clearing data after collection<br> <li> Fixed bug where orientation data was being cleared before metadata <br>collection


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/330/files#diff-5818bbda90dfe6e47c2417716ff38df6fa5fab3eadd63b6e4763ca2643a706a1">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>