### PR TITLE
Fix/emulator check

### DIFF
--- a/Example/SmileID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SmileID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dd10be05b79b8cde0e51ad7d271977fd3ad14c19b9d212888e81e42ea39ae55c",
+  "originHash" : "a8ee3617518608160442ee1fbb39c08d56292f902f8d574ecd154cbce7e1e0d8",
   "pins" : [
     {
       "identity" : "fingerprintjs-ios",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "ca92efeb24b10052cd2a79e5205f42c5a16770ec",
-        "version" : "8.53.2"
+        "revision" : "156495496cb101e2f0a6b059f12dafcff1912197",
+        "version" : "8.54.0"
       }
     },
     {

--- a/Sources/Classes/Metadata/Device/BuildInfo.swift
+++ b/Sources/Classes/Metadata/Device/BuildInfo.swift
@@ -1,0 +1,35 @@
+
+struct BuildInfo {
+  var platform: String
+  var buildSource: String
+
+  func toCodableObject() -> [String: CodableValue] {
+    [
+      "platform": .string(platform),
+      "build_source": .string(buildSource),
+    ]
+  }
+}
+
+func getBuildInfo() -> BuildInfo {
+  let platform = Platform.iphone.rawValue
+  let info = ProcessInfo.processInfo
+  if info.isMacCatalystApp {
+    platform = Platform.mac.rawValue
+  }
+  if #available(iOS 14.0, *) {
+    if info.isiOSAppOnMac {
+      platform = Platform.mac.rawValue
+    }
+  }
+  if info.environment["SIMULATOR_MODEL_IDENTIFIER"] != nil {
+    platform = Platform.simulator.rawValue
+  }
+  let buildSource = Bundle.main.appStoreReceiptURL
+  let buildInfo = BuildInfo(
+    platform: platform,
+    buildSource: buildSource
+  )
+  print(buildInfo)
+  return buildInfo
+}

--- a/Sources/Classes/Metadata/Device/UIDeviceExtension.swift
+++ b/Sources/Classes/Metadata/Device/UIDeviceExtension.swift
@@ -3,21 +3,15 @@ import UIKit
 
 extension UIDevice {
   var modelName: String {
-    #if targetEnvironment(simulator)
-      let identifier = ProcessInfo().environment[
-        "SIMULATOR_MODEL_IDENTIFIER"
-      ]!
-    #else
-      var systemInfo = utsname()
-      uname(&systemInfo)
-      let machineMirror = Mirror(reflecting: systemInfo.machine)
-      let identifier = machineMirror.children.reduce("") { identifier, element in
-        guard let value = element.value as? Int8, value != 0 else {
-          return identifier
-        }
-        return identifier + String(UnicodeScalar(UInt8(value)))
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machineMirror = Mirror(reflecting: systemInfo.machine)
+    let identifier = machineMirror.children.reduce("") { identifier, element in
+      guard let value = element.value as? Int8, value != 0 else {
+        return identifier
       }
-    #endif
+      return identifier + String(UnicodeScalar(UInt8(value)))
+    }
     return DeviceModel.all.first { $0.identifier == identifier }?.model
       ?? identifier
   }

--- a/Sources/Classes/Metadata/Metadata.swift
+++ b/Sources/Classes/Metadata/Metadata.swift
@@ -29,6 +29,7 @@ class Metadata {
 
   private func setDefaultMetadata() {
     addMetadata(key: .activeLivenessVersion, value: "1.0.0")
+    addMetadata(key: .buildInfo, value: getBuildInfo().toCodableObject())
     addMetadata(key: .clientIP, value: getIPAddress(useIPv4: true))
     addMetadata(key: .deviceModel, value: UIDevice.current.modelName)
     addMetadata(key: .deviceOS, value: UIDevice.current.systemVersion)

--- a/Sources/Classes/Metadata/Metadata.swift
+++ b/Sources/Classes/Metadata/Metadata.swift
@@ -29,7 +29,9 @@ class Metadata {
 
   private func setDefaultMetadata() {
     addMetadata(key: .activeLivenessVersion, value: "1.0.0")
-    addMetadata(key: .buildInfo, value: getBuildInfo().toCodableObject())
+    Task {
+      await addMetadata(key: .buildInfo, value: getBuildInfo().toCodableObject())
+    }
     addMetadata(key: .clientIP, value: getIPAddress(useIPv4: true))
     addMetadata(key: .deviceModel, value: UIDevice.current.modelName)
     addMetadata(key: .deviceOS, value: UIDevice.current.systemVersion)

--- a/Sources/Classes/Metadata/Models/MetadataKey.swift
+++ b/Sources/Classes/Metadata/Models/MetadataKey.swift
@@ -3,6 +3,7 @@ import Foundation
 enum MetadataKey: String {
   case activeLivenessType = "active_liveness_type"
   case activeLivenessVersion = "active_liveness_version"
+  case buildInfo = "build_info"
   case cameraName = "camera_name"
   case clientIP = "client_ip"
   case deviceModel = "device_model"

--- a/Sources/Classes/Metadata/Models/MetadataModels.swift
+++ b/Sources/Classes/Metadata/Models/MetadataModels.swift
@@ -24,3 +24,9 @@ public enum WrapperSdkName: String {
   case reactNative = "react_native"
   case reactNativeExpo = "react_native_expo"
 }
+
+public enum Platform: String {
+  case mac
+  case simulator
+  case iphone
+}

--- a/Sources/Resources/devicemodels.json
+++ b/Sources/Resources/devicemodels.json
@@ -1,17 +1,5 @@
 [
   {
-    "identifier": "i386",
-    "model": "iPhone Simulator"
-  },
-  {
-    "identifier": "x86_64",
-    "model": "iPhone Simulator"
-  },
-  {
-    "identifier": "arm64",
-    "model": "iPhone Simulator"
-  },
-  {
     "identifier": "iPhone1,1",
     "model": "iPhone"
   },


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/17603/fix-and-improve-existing-emulator-check

## Summary
This PR follows the discussion of https://smileidentity.slack.com/archives/C088HUCQ9T7/p1754058272422099 and fixes the iOS simulator check and adds some additional information such as platform information and build source information (via app transaction)

## Performance impact
Getting the AppTransaction information adds a internal call to Apples servers. This takes on average < 1s and is executed via a task and runs in the background whilst the user is performing the enrollment. In addition, this adds the signed JWS from Apple to the payload

## Test Instructions
Run any enrollment with metadata (eg. selfie enrol) and check if the correct information is added into the build source.

## Screenshot
