### PR TITLE
flatten build info

### DIFF
--- a/Sources/Classes/Metadata/Device/BuildInfo.swift
+++ b/Sources/Classes/Metadata/Device/BuildInfo.swift
@@ -1,34 +1,24 @@
 import Foundation
 import StoreKit
 
-struct BuildInfo {
-  var platform: String
-  var buildSource: String
-
-  func toCodableObject() -> [String: CodableValue] {
-    [
-      "platform": .string(platform),
-      "build_source": .string(buildSource)
-    ]
-  }
-}
-
-func getBuildInfo() async -> BuildInfo {
-  var platform = Platform.iphone.rawValue
+func getBuildPlatform() -> String {
   let info = ProcessInfo.processInfo
   if info.isMacCatalystApp {
-    platform = Platform.mac.rawValue
+    return Platform.mac.rawValue
   }
   if #available(iOS 14.0, *) {
     if info.isiOSAppOnMac {
-      platform = Platform.mac.rawValue
+      return Platform.mac.rawValue
     }
   }
   if info.environment["SIMULATOR_MODEL_IDENTIFIER"] != nil {
-    platform = Platform.simulator.rawValue
+    return Platform.simulator.rawValue
   }
+  return Platform.iphone.rawValue
+}
 
-  let buildSource: String = await {
+func getBuildReceipt() async -> String {
+  await {
     if #available(iOS 16.0, *) {
       do {
         let result = try await AppTransaction.shared
@@ -43,10 +33,4 @@ func getBuildInfo() async -> BuildInfo {
       return "unknown"
     }
   }()
-
-  let buildInfo = BuildInfo(
-    platform: platform,
-    buildSource: buildSource
-  )
-  return buildInfo
 }

--- a/Sources/Classes/Metadata/Metadata.swift
+++ b/Sources/Classes/Metadata/Metadata.swift
@@ -29,9 +29,10 @@ class Metadata {
 
   private func setDefaultMetadata() {
     addMetadata(key: .activeLivenessVersion, value: "1.0.0")
+    addMetadata(key: .buildPlatform, value: getBuildPlatform())
     Task {
-      let buildInfo = await getBuildInfo()
-      addMetadata(key: .buildInfo, value: buildInfo.toCodableObject())
+      let buildReceipt = await getBuildReceipt()
+      addMetadata(key: .buildReceipt, value: buildReceipt)
     }
     addMetadata(key: .clientIP, value: getIPAddress(useIPv4: true))
     addMetadata(key: .deviceModel, value: UIDevice.current.modelName)

--- a/Sources/Classes/Metadata/Models/MetadataKey.swift
+++ b/Sources/Classes/Metadata/Models/MetadataKey.swift
@@ -3,7 +3,8 @@ import Foundation
 enum MetadataKey: String {
   case activeLivenessType = "active_liveness_type"
   case activeLivenessVersion = "active_liveness_version"
-  case buildInfo = "build_info"
+  case buildPlatform = "build_platform"
+  case buildReceipt = "build_receipt"
   case cameraName = "camera_name"
   case clientIP = "client_ip"
   case deviceModel = "device_model"


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/17603/fix-and-improve-existing-emulator-check

## Summary

Given the structure how we store metadata in the backend in our database it is better if our metadata is of types key value pairs instead of a nested objects. This PR flattens the previously introduced build_info object into separate keys.

## Known Issues


## Test Instructions
Run an enrollment with metadata and observe the new keys.

## Screenshot


___

### **PR Type**
Enhancement


___

### **Description**
- Flatten nested build info metadata structure into separate key-value pairs

- Replace single `build_info` object with `build_platform` and `build_receipt` keys

- Refactor build info functions to return individual values

- Improve metadata storage compatibility with backend database requirements


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildInfo.swift</strong><dd><code>Split build info into separate functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/Classes/Metadata/Device/BuildInfo.swift

<ul><li>Remove <code>BuildInfo</code> struct and its <code>toCodableObject()</code> method<br> <li> Split <code>getBuildInfo()</code> into separate <code>getBuildPlatform()</code> and <br><code>getBuildReceipt()</code> functions<br> <li> Simplify platform detection logic to return string directly<br> <li> Extract build receipt logic into dedicated async function</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/390/files#diff-27f18ab673e0651de396ae34fdf514e859d0810685ce00f13a67202b6cf20372">+8/-24</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Metadata.swift</strong><dd><code>Update metadata to use flattened build info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/Classes/Metadata/Metadata.swift

<ul><li>Replace nested <code>build_info</code> metadata with separate <code>build_platform</code> and <br><code>build_receipt</code> keys<br> <li> Call individual functions instead of single <code>getBuildInfo()</code> function<br> <li> Add synchronous platform metadata and async receipt metadata <br>separately</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/390/files#diff-672ac594b25ee4a9ceb8aa77fad7edcb32e0e343bb16291eba89a541e375bc99">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MetadataKey.swift</strong><dd><code>Replace build info key with platform and receipt keys</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/Classes/Metadata/Models/MetadataKey.swift

<ul><li>Remove <code>buildInfo</code> enum case<br> <li> Add <code>buildPlatform</code> and <code>buildReceipt</code> enum cases<br> <li> Update metadata key definitions for flattened structure</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/390/files#diff-e96634e8e34c2cd1e6c747f259bb73799de4e6f00356b43fa66234251bc3d4e6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>