### PR TITLE
Fix AutoCaptureOnly

### DIFF
--- a/Sources/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift
+++ b/Sources/Classes/DocumentVerification/Model/DocumentCaptureViewModel.swift
@@ -108,7 +108,7 @@ class DocumentCaptureViewModel: ObservableObject {
         if let documentFirstDetectedAtTime = self.documentFirstDetectedAtTime {
           let now = Date().timeIntervalSince1970
           let elapsedTime = now - documentFirstDetectedAtTime
-          if elapsedTime > autoCaptureTimeout,
+          if elapsedTime > 1.0,
              !self.isCapturing,
              [.autoCapture, .autoCaptureOnly].contains(autoCapture) {
             self.documentImageOrigin = DocumentImageOriginValue.cameraAutoCapture


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

* Update auto capture timeout condition to a fixed value of 1 second

## Known Issues

N/A

## Test Instructions

* Launch Document Verification product with `autoCapture` set to `autoCaptureOnly`
* Confirm that document auto captures after 1seconds of the document cutout border showing green.

## Screenshot

N/A
