### PR TITLE
chore: update SmileID binaries to v11.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 11.1.9 - March 12, 2026
+
+### Fixed
+* Fixed the PartnerParams encoding and decoding to use an int instead of a string 
+
 ## 11.1.8 - March 11, 2026
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "SmileIDSDK",
-      url: "https://github.com/smileidentity/ios/releases/download/v11.1.9/SmileIDSDK.xcframework.zipö39b168aaff5306f51e9ef34460681c31dfb489cb51f85a60a9375dc7c31402"
+      url: "https://github.com/smileidentity/ios/releases/download/v11.1.9/SmileIDSDK.xcframework.zip",
+      checksum: "34218f27f6a847ad93ca5c037f464a68d097d205c76de6347c4163a6afb9a369"
     )
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,7 @@ let package = Package(
     ),
     .binaryTarget(
       name: "SmileIDSDK",
-      url: "https://github.com/smileidentity/ios/releases/download/v11.1.8/SmileIDSDK.xcframework.zip",
-      checksum: "80ee203c4e3a49eab412096bb10f7ba77ccdead3de85cd5bd57adff76088bc7b"
+      url: "https://github.com/smileidentity/ios/releases/download/v11.1.9/SmileIDSDK.xcframework.zipö39b168aaff5306f51e9ef34460681c31dfb489cb51f85a60a9375dc7c31402"
     )
   ]
 )

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '11.1.8'
+  s.version          = '11.1.9'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   }
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.9'
-  s.source           = { :http => "https://github.com/smileidentity/ios/releases/download/v#{s.version}/SmileIDSDK-xcframeworks-v#{s.version}.zip", :sha256 => 'f0702d05d97038a2fb66ac684a2546ad613d0def19c2dffc1624ac177374650e' }
+  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.9/SmileIDSDK-xcframeworks-v11.1.9.zip', :sha256 => 'f0702d05d97038a2fb66ac684a2546ad613d0def19c2dffc1624ac177374650e' }
   s.vendored_frameworks = "SmileIDSDK.xcframework", "Lottie.xcframework"
 
   s.dependency 'ZIPFoundation', '0.9.20'

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = 'SmileIDSDK'
-  s.version          = '11.1.9'
+  s.version = '11.1.9'
   s.summary = 'Binary SmileID SDK module.'
   s.homepage = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license  = { :type => 'MIT' }

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.9'
   s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.9/SmileIDSDK-xcframeworks-v11.1.9.zip', :sha256 => 'f0702d05d97038a2fb66ac684a2546ad613d0def19c2dffc1624ac177374650e' }
-  s.vendored_frameworks = "SmileIDSDK.xcframework", "Lottie.xcframework"
+  s.vendored_frameworks = 'SmileIDSDK-xcframeworks/SmileIDSDK.xcframework', 'SmileIDSDK-xcframeworks/Lottie.xcframework'
 
   s.dependency 'ZIPFoundation', '0.9.20'
   s.dependency 'FingerprintJS', '1.6.0'

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = 'SmileIDSDK'
-  s.version = '11.1.8'
+  s.version          = '11.1.9'
   s.summary = 'Binary SmileID SDK module.'
   s.homepage = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license  = { :type => 'MIT' }
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   }
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.9'
-  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.8/SmileIDSDK-xcframeworks-v11.1.8.zip', :sha256 => 'bc9f2899c040c4a2ba75652b21bbeb8041ba036b8a7ab656442c5b7260191bef' }
-  s.vendored_frameworks = 'SmileIDSDK-xcframeworks/SmileIDSDK.xcframework', 'SmileIDSDK-xcframeworks/Lottie.xcframework'
+  s.source           = { :http => "https://github.com/smileidentity/ios/releases/download/v#{s.version}/SmileIDSDK-xcframeworks-v#{s.version}.zip", :sha256 => 'f0702d05d97038a2fb66ac684a2546ad613d0def19c2dffc1624ac177374650e' }
+  s.vendored_frameworks = "SmileIDSDK.xcframework", "Lottie.xcframework"
 
   s.dependency 'ZIPFoundation', '0.9.20'
   s.dependency 'FingerprintJS', '1.6.0'


### PR DESCRIPTION
### **User description**
Automated update to consume the SmileID iOS SDK v11.1.9 XCFramework binaries.

- Updates Package.swift to reference the published binary targets (SmileIDSDK).
- Updates SmileIDSDK.podspec to vend the new XCFramework bundle.

Generated by the ios-sdk release workflow.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Update SmileID SDK binaries to v11.1.9

- Fix podspec to use version interpolation for source URL

- Simplify vendored framework paths in podspec

- Potential bug: malformed URL/checksum in Package.swift


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Release["v11.1.9 Release"]
  SPM["Package.swift"]
  CocoaPods["SmileIDSDK.podspec"]
  Release -- "new binary URL + checksum" --> SPM
  Release -- "version bump + dynamic URL" --> CocoaPods
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Package.swift</strong><dd><code>Update SPM binary target to v11.1.9</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Package.swift

<ul><li>Updated binary target URL from v11.1.8 to v11.1.9<br> <li> Replaced separate <code>checksum</code> parameter with what appears to be an inline <br>checksum appended to the URL (possibly malformed — missing <code>"</code> delimiter <br>and <code>checksum:</code> field)</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/455/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileIDSDK.podspec</strong><dd><code>Bump podspec version and use dynamic source URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileIDSDK.podspec

<ul><li>Bumped version from <code>11.1.8</code> to <code>11.1.9</code><br> <li> Changed source URL to use version interpolation (<code>s.version</code>) instead of <br>hardcoded version strings<br> <li> Updated SHA256 checksum for the new release archive<br> <li> Simplified <code>vendored_frameworks</code> paths by removing the <br><code>SmileIDSDK-xcframeworks/</code> prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/455/files#diff-e2677e36ff8c7dc8b8ae5b17051961542e66ff4ef08168a7c53da75accfd55b6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>