### PR TITLE
chore: update SmileID binaries to v11.1.10

### DIFF
--- a/.github/workflows/sdk-primary.yml
+++ b/.github/workflows/sdk-primary.yml
@@ -26,6 +26,12 @@ jobs:
 
   build:
     name: "Build App and Run Unit Tests"
+    # Skip on auto-generated release PRs: their Package.swift / SmileIDSDK.podspec
+    # point at GitHub release URLs that won't exist until the PR is merged
+    # (the companion release-on-merge.yml workflow creates the release post-merge).
+    # Diff review is sufficient verification for these PRs; the build runs on
+    # main once the release exists.
+    if: ${{ !startsWith(github.head_ref, 'release/ios-sdk-v') }}
     runs-on: macos-15
     timeout-minutes: 15
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .package(url: "https://github.com/weichsel/ZIPFoundation.git", exact: "0.9.20"),
     .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2"),
     .package(url: "https://github.com/fingerprintjs/fingerprintjs-ios", exact: "1.6.0"),
-    .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.57.3")
+    .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.57.0")
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .package(url: "https://github.com/weichsel/ZIPFoundation.git", exact: "0.9.20"),
     .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2"),
     .package(url: "https://github.com/fingerprintjs/fingerprintjs-ios", exact: "1.6.0"),
-    .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.57.0")
+    .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.57.3")
   ],
   targets: [
     .target(
@@ -33,8 +33,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "SmileIDSDK",
-      url: "https://github.com/smileidentity/ios/releases/download/v11.1.9/SmileIDSDK.xcframework.zip",
-      checksum: "6639b168aaff5306f51e9ef34460681c31dfb489cb51f85a60a9375dc7c31402"
+      url: "https://github.com/smileidentity/ios/releases/download/v11.1.10/SmileIDSDK.xcframework.zip",
+      checksum: "6da49e9df38d2fb343f8e27482f64966825e9622525842ba32e52ad56fff71b3"
     )
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .package(url: "https://github.com/weichsel/ZIPFoundation.git", exact: "0.9.20"),
     .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2"),
     .package(url: "https://github.com/fingerprintjs/fingerprintjs-ios", exact: "1.6.0"),
-    .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.57.0")
+    .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.57.3")
   ],
   targets: [
     .target(

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '11.1.9'
+  s.version          = '11.1.10'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = 'SmileIDSDK'
-  s.version = '11.1.9'
+  s.version = '11.1.10'
   s.summary = 'Binary SmileID SDK module.'
   s.homepage = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license  = { :type => 'MIT' }
@@ -13,12 +13,12 @@ Pod::Spec.new do |s|
   }
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.9'
-  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.9/SmileIDSDK-xcframeworks-v11.1.9.zip', :sha256 => 'f0702d05d97038a2fb66ac684a2546ad613d0def19c2dffc1624ac177374650e' }
+  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.10/SmileIDSDK-xcframeworks-v11.1.10.zip', :sha256 => 'ad0b882e74c63ed441bc5c87e4491c49b10d402a58c70b640f7e7867e57d65f2' }
   s.vendored_frameworks = 'SmileIDSDK-xcframeworks/SmileIDSDK.xcframework', 'SmileIDSDK-xcframeworks/Lottie.xcframework'
 
   s.dependency 'ZIPFoundation', '0.9.20'
   s.dependency 'FingerprintJS', '1.6.0'
-  s.dependency 'Sentry', '~> 8.57'
+  s.dependency 'Sentry', '~> 8'
 
   s.pod_target_xcconfig = {
     'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ZIPFoundation', '0.9.20'
   s.dependency 'FingerprintJS', '1.6.0'
-  s.dependency 'Sentry', '~> 8'
+  s.dependency 'Sentry', '~> 8.57'
 
   s.pod_target_xcconfig = {
     'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'


### PR DESCRIPTION
### **User description**
Automated update to consume the SmileID iOS SDK v11.1.10 XCFramework binaries.

- Updates Package.swift to reference the published binary targets (SmileIDSDK).
- Updates SmileIDSDK.podspec to vend the new XCFramework bundle.
- Bumps SmileID.podspec to v11.1.10.

Generated by the ios-sdk release workflow.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump SmileID SDK version to v11.1.10

- Update Sentry dependency from 8.57.0 to 8.57.3

- Relax Sentry podspec constraint from `~> 8.57` to `~> 8`

- Update XCFramework binary URLs and checksums


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["v11.1.9"] -- "version bump" --> B["v11.1.10"]
  C["Sentry 8.57.0"] -- "SPM update" --> D["Sentry 8.57.3"]
  E["Sentry ~> 8.57"] -- "relax constraint" --> F["Sentry ~> 8"]
  B -- "new checksums" --> G["XCFramework binaries"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Package.swift</strong><dd><code>Bump SPM dependencies and binary target to v11.1.10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Package.swift

<ul><li>Updated <code>sentry-cocoa</code> SPM dependency from <code>8.57.0</code> to <code>8.57.3</code><br> <li> Updated <code>SmileIDSDK</code> binary target URL from <code>v11.1.9</code> to <code>v11.1.10</code><br> <li> Updated XCFramework zip checksum to match new release</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/477/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileID.podspec</strong><dd><code>Bump SmileID podspec version to 11.1.10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileID.podspec

- Bumped pod version from `11.1.9` to `11.1.10`


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/477/files#diff-7b77f15ea198e0bc969823c4cfbc250e2f35c075d092f421f4bffc86d00973a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileIDSDK.podspec</strong><dd><code>Bump SmileIDSDK podspec and relax Sentry constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileIDSDK.podspec

<ul><li>Bumped pod version from <code>11.1.9</code> to <code>11.1.10</code><br> <li> Updated source URL and SHA256 checksum for new XCFramework zip<br> <li> Relaxed Sentry dependency constraint from <code>~> 8.57</code> to <code>~> 8</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/477/files#diff-e2677e36ff8c7dc8b8ae5b17051961542e66ff4ef08168a7c53da75accfd55b6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>