### PR TITLE
ci: drop SmileID.podspec auto-push, drop redundant CHANGELOG sync

### DIFF
--- a/.github/workflows/push-smileid-podspec.yml
+++ b/.github/workflows/push-smileid-podspec.yml
@@ -1,0 +1,94 @@
+# Manually push SmileID.podspec to CocoaPods Trunk after a release.
+#
+# `release-on-merge.yml` does NOT push SmileID.podspec because it depends on
+# `SmileIDSDK == version`, and CocoaPods Trunk's aggregate index file lags the
+# per-version spec by 30 min – several hours after a push. Until the index
+# catches up, `pod trunk push SmileID.podspec` fails dependency validation.
+#
+# After a release is merged, monitor `pod trunk info SmileIDSDK` (or the
+# all_pods_versions CDN index) and trigger this workflow once the new version
+# appears. The workflow pre-flights the CDN check so dispatching it too early
+# fails fast (no wasted CocoaPods validation time).
+#
+# Required secrets: COCOAPODS_TRUNK_TOKEN
+
+name: Push SmileID.podspec
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to push (leave blank to use s.version from SmileID.podspec on main)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: push-smileid-podspec
+  cancel-in-progress: false
+
+jobs:
+  push:
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+
+      - name: Determine version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_VERSION}" ]]; then
+            version="${INPUT_VERSION}"
+          else
+            version="$(awk -F\' '/^\s*s\.version\s*=/ { print $2; exit }' SmileID.podspec)"
+          fi
+          if [[ -z "${version}" ]]; then
+            echo "::error::Could not determine version (no input and SmileID.podspec has no s.version line)"
+            exit 1
+          fi
+          if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?(\+[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Version '${version}' is not valid semver"
+            exit 1
+          fi
+          echo "Pushing SmileID v${version}"
+          echo "value=${version}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${version}" >> "$GITHUB_ENV"
+
+      - name: Pre-flight — confirm SmileIDSDK is indexed on the CocoaPods CDN
+        run: |
+          set -euo pipefail
+          hash=$(printf '%s' "SmileIDSDK" | md5)
+          url="https://cdn.cocoapods.org/all_pods_versions_${hash:0:1}_${hash:1:1}_${hash:2:1}.txt"
+          echo "Index: ${url}"
+          versions="$(curl -sfL "${url}" | grep '^SmileIDSDK/' || true)"
+          echo "Indexed versions: ${versions}"
+          if ! printf '%s\n' "${versions}" | grep -q "/${VERSION}\(/\|$\)"; then
+            echo "::error::SmileIDSDK ${VERSION} is not yet listed in the CocoaPods CDN index."
+            echo "::error::Trunk-to-CDN propagation typically takes 30 min – several hours after the push."
+            echo "::error::Wait and re-run this workflow, or push locally:"
+            echo "::error::  pod trunk push SmileID.podspec --allow-warnings"
+            exit 1
+          fi
+          echo "SmileIDSDK ${VERSION} is indexed; safe to proceed."
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: false
+
+      - name: Install CocoaPods
+        run: gem install cocoapods --no-document
+
+      - name: Push SmileID.podspec to CocoaPods Trunk
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push SmileID.podspec --allow-warnings

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,8 +1,3 @@
-# Triggered when an automated release PR (branch: release/ios-sdk-v*) from the
-# ios-sdk repo is merged into main. Tags the merge commit, creates the public
-# GitHub release with artifacts mirrored from ios-sdk, pushes both podspecs to
-# CocoaPods Trunk, and opens a release-notes PR syncing CHANGELOG.md.
-#
 # Required secrets: GH_PAT, COCOAPODS_TRUNK_TOKEN
 
 name: Release on Merge
@@ -114,7 +109,7 @@ jobs:
           done
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         with:
@@ -140,88 +135,3 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: pod trunk push SmileIDSDK.podspec --allow-warnings
-
-      - name: Wait for SmileIDSDK to appear on the CocoaPods CDN
-        run: |
-          set -euo pipefail
-          pod_name="SmileIDSDK"
-          hash=$(printf '%s' "${pod_name}" | md5)
-          url="https://cdn.cocoapods.org/Specs/${hash:0:1}/${hash:1:1}/${hash:2:1}/${pod_name}/${RELEASE_VERSION}/${pod_name}.podspec.json"
-          echo "Polling ${url}"
-          for i in $(seq 1 40); do
-            if curl -sfLI "${url}" > /dev/null; then
-              echo "${pod_name} v${RELEASE_VERSION} indexed on attempt ${i}"
-              exit 0
-            fi
-            echo "attempt ${i}/40: not yet indexed, sleeping 15s"
-            sleep 15
-          done
-          echo "::error::Timed out waiting for ${pod_name} v${RELEASE_VERSION} on the CocoaPods CDN after 10 minutes"
-          exit 1
-
-      - name: Push SmileID.podspec to CocoaPods Trunk
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: pod trunk push SmileID.podspec --allow-warnings
-
-      - name: Prepare CHANGELOG update on main
-        id: changelog
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          set -euo pipefail
-          gh api repos/smileidentity/ios-sdk/contents/CHANGELOG.md \
-            --jq '.content' | base64 --decode > /tmp/sdk-changelog.md
-
-          section=$(awk -v ver="${RELEASE_VERSION}" '
-            $0 ~ "^## " ver "([[:space:]]|$)" { found=1; print; next }
-            found && /^## / { exit }
-            found { print }
-          ' /tmp/sdk-changelog.md)
-
-          if [[ -z "${section}" ]]; then
-            echo "::warning::No CHANGELOG section found for v${RELEASE_VERSION} in ios-sdk; skipping sync"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git fetch origin main
-          git checkout main
-          git pull --ff-only origin main
-
-          if awk -v ver="${RELEASE_VERSION}" '
-            $0 ~ "^## " ver "([[:space:]]|$)" { found=1; exit }
-            END { exit !found }
-          ' CHANGELOG.md; then
-            echo "CHANGELOG.md already contains v${RELEASE_VERSION} entry; skipping sync"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          {
-            head -n 1 CHANGELOG.md
-            echo
-            printf '%s\n' "${section}"
-            tail -n +2 CHANGELOG.md
-          } > /tmp/changelog-new.md
-          mv /tmp/changelog-new.md CHANGELOG.md
-
-          if git diff --quiet CHANGELOG.md; then
-            echo "CHANGELOG.md unchanged; nothing to commit"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      - name: Create CHANGELOG PR
-        if: steps.changelog.outputs.skip != 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
-        with:
-          token: ${{ secrets.GH_PAT }}
-          commit-message: "chore: sync CHANGELOG for v${{ env.RELEASE_VERSION }}"
-          title: "iOS v${{ env.RELEASE_VERSION }} Release Notes"
-          body: Automated PR to sync release notes from the ios-sdk CHANGELOG.
-          branch: release-notes/v${{ env.RELEASE_VERSION }}
-          base: main
-          labels: "release-notes"
-          team-reviewers: "smileidentity/mobile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 11.1.10 - April 29, 2026
+
+### Fixed
+* Fixed BiometricKYC `onSuccess` returning stale file URLs that pointed to non-existent files after job submission
+* Fixed duplicate Sentry SDK linking when host apps also depend on Sentry by vendoring it as an xcframework
+
 ## 11.1.9 - March 12, 2026
 
 ### Fixed


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

A few sentences/bullet points about the changes

## Known Issues

Any shortcomings in your work. This may include corner cases not correctly handled or issues related
to but not within the scope of your PR. Design compromises should be discussed here if they were not
already discussed above.

## Test Instructions

Concise test instructions on how to verify that your feature works as intended. This should include
changes to the development environment (if applicable) and all commands needed to run your work.

## Screenshot

If applicable (e.g. UI changes), add screenshots to help explain your work.


___

### **PR Type**
Enhancement


___

### **Description**
- Drop auto-push of `SmileID.podspec` from release workflow

- Add manual `push-smileid-podspec.yml` workflow with CDN pre-flight check

- Remove post-merge CHANGELOG sync steps from release workflow

- Pin `softprops/action-gh-release` to v2.6.1 and backfill v11.1.10 release notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["release-on-merge.yml"] -- "removed" --> B["SmileID.podspec auto-push"]
  A -- "removed" --> C["CHANGELOG sync steps"]
  A -- "pinned" --> D["action-gh-release v2.6.1"]
  E["push-smileid-podspec.yml"] -- "new manual workflow" --> F["CDN pre-flight + pod trunk push"]
  G["CHANGELOG.md"] -- "backfill" --> H["v11.1.10 release notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>push-smileid-podspec.yml</strong><dd><code>Add manual SmileID.podspec push workflow with CDN check</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/push-smileid-podspec.yml

<ul><li>New manual <code>workflow_dispatch</code> workflow for pushing <code>SmileID.podspec</code> to <br>CocoaPods Trunk<br> <li> Accepts optional version input; falls back to parsing <code>s.version</code> from <br>the podspec<br> <li> Includes semver validation and CDN pre-flight check to confirm <br><code>SmileIDSDK</code> is indexed before pushing<br> <li> Sets up Ruby 3.2, installs CocoaPods, and runs <code>pod trunk push</code> with <br><code>--allow-warnings</code></ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/478/files#diff-4022d6c4ad1278aea7ce1068cb2be5615510838a3198639f303604ec99222d7d">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-on-merge.yml</strong><dd><code>Drop SmileID podspec push and CHANGELOG sync from release workflow</code></dd></summary>
<hr>

.github/workflows/release-on-merge.yml

<ul><li>Removed top-level comment block describing the full workflow scope<br> <li> Pinned <code>softprops/action-gh-release</code> from v2 (latest) to v2.6.1 to fix <br>PAT-based release event firing<br> <li> Removed the <code>Wait for SmileIDSDK to appear on the CocoaPods CDN</code> polling <br>step<br> <li> Removed the <code>Push SmileID.podspec to CocoaPods Trunk</code> step<br> <li> Removed the <code>Prepare CHANGELOG update on main</code> and <code>Create CHANGELOG PR</code> <br>steps</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/478/files#diff-014acb62cbe0b3a074e82cc7d47b4c76a9374b1846d450780f36a3e7432192fd">+1/-91</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Backfill v11.1.10 release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Backfilled v11.1.10 release notes (April 29, 2026) that were missed <br>due to prior workflow failure<br> <li> Documents fixes for stale BiometricKYC file URLs and duplicate Sentry <br>SDK linking</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/478/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>