### PR TITLE
chore: update SmileID binaries to v11.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 11.1.11 - May 14, 2026
+
+### Added
+* Collect more metadata
+
 ## 11.1.10 - April 29, 2026
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "SmileIDSDK",
-      url: "https://github.com/smileidentity/ios/releases/download/v11.1.10/SmileIDSDK.xcframework.zip",
-      checksum: "6da49e9df38d2fb343f8e27482f64966825e9622525842ba32e52ad56fff71b3"
+      url: "https://github.com/smileidentity/ios/releases/download/v11.1.11/SmileIDSDK.xcframework.zip",
+      checksum: "7b3922ba1dd1a617bbbb0a1ddacb1990625a2e7c5257dcfceb3f229ee6f8c64d"
     )
   ]
 )

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '11.1.10'
+  s.version          = '11.1.11'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = 'SmileIDSDK'
-  s.version = '11.1.10'
+  s.version = '11.1.11'
   s.summary = 'Binary SmileID SDK module.'
   s.homepage = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license  = { :type => 'MIT' }
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   }
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.9'
-  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.10/SmileIDSDK-xcframeworks-v11.1.10.zip', :sha256 => 'ad0b882e74c63ed441bc5c87e4491c49b10d402a58c70b640f7e7867e57d65f2' }
+  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.11/SmileIDSDK-xcframeworks-v11.1.11.zip', :sha256 => 'fd91accdc13116b05938ff13912b5b7928b15228675ad0e300f58c0c799fedf8' }
   s.vendored_frameworks = 'SmileIDSDK-xcframeworks/SmileIDSDK.xcframework', 'SmileIDSDK-xcframeworks/Lottie.xcframework'
 
   s.dependency 'ZIPFoundation', '0.9.20'


### PR DESCRIPTION
### **User description**
Automated update to consume the SmileID iOS SDK v11.1.11 XCFramework binaries.

- Updates Package.swift to reference the published binary targets (SmileIDSDK).
- Updates SmileIDSDK.podspec to vend the new XCFramework bundle.
- Bumps SmileID.podspec to v11.1.11.
- Prepends the v11.1.11 section into CHANGELOG.md (mirrored from the SDK's CHANGELOG.md), so the release tag points at a commit that already contains the matching release notes.

## After merging — manual follow-up: push SmileID.podspec

On merge, `release-on-merge.yml` will automatically tag the merge commit, create the public GitHub release, and `pod trunk push SmileIDSDK.podspec`. **`SmileID.podspec` is not pushed automatically** — CocoaPods Trunk's aggregate index file lags the per-version spec by 30 min – several hours, and an immediate push fails dependency validation.

**Recommended:** once `pod trunk info SmileIDSDK` lists `11.1.11` in the CDN index, trigger the **Push SmileID.podspec** workflow from the Actions tab on `smileidentity/ios`:

<https://github.com/smileidentity/ios/actions/workflows/push-smileid-podspec.yml>

Click **Run workflow** → leave the version blank (it auto-detects from `main`) → **Run workflow**. The job pre-flights the CDN-index check, so dispatching too early fails fast with a clear error instead of wasting CocoaPods validation time.

**Alternative — push locally from `main`:**

```
pod trunk push SmileID.podspec --allow-warnings
```

Quick CDN-index readiness check (returns `ready` or `not yet`):

```
hash=$(printf '%s' "SmileIDSDK" | md5)
curl -sfL "https://cdn.cocoapods.org/all_pods_versions_${hash:0:1}_${hash:1:1}_${hash:2:1}.txt" \
  | grep "^SmileIDSDK/" | grep -q 11.1.11 && echo ready || echo "not yet"
```

Generated by the ios-sdk release workflow.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump SmileID iOS SDK to v11.1.11

- Update XCFramework binary URLs and checksums

- Update podspec versions for SmileID and SmileIDSDK

- Add v11.1.11 changelog entry (metadata collection)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Release["v11.1.11 Release"]
  SPM["Package.swift"]
  PodSDK["SmileIDSDK.podspec"]
  PodMain["SmileID.podspec"]
  CL["CHANGELOG.md"]
  Release -- "new URL + checksum" --> SPM
  Release -- "new version + source" --> PodSDK
  Release -- "version bump" --> PodMain
  Release -- "release notes" --> CL
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Package.swift</strong><dd><code>Update SPM binary target to v11.1.11</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Package.swift

<ul><li>Updated binary target URL from v11.1.10 to v11.1.11<br> <li> Updated checksum to match the new XCFramework zip</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/483/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileID.podspec</strong><dd><code>Bump SmileID podspec version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileID.podspec

- Bumped version from 11.1.10 to 11.1.11


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/483/files#diff-7b77f15ea198e0bc969823c4cfbc250e2f35c075d092f421f4bffc86d00973a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileIDSDK.podspec</strong><dd><code>Bump SmileIDSDK podspec version and source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileIDSDK.podspec

<ul><li>Bumped version from 11.1.10 to 11.1.11<br> <li> Updated source URL and SHA256 hash for the new XCFramework bundle</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/483/files#diff-e2677e36ff8c7dc8b8ae5b17051961542e66ff4ef08168a7c53da75accfd55b6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add v11.1.11 changelog entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added v11.1.11 release notes section dated May 14, 2026<br> <li> Documents "Collect more metadata" as an addition</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/483/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>