### PR TITLE
Import Semgrep SARIF results into DefectDojo

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,6 +32,31 @@ jobs:
         with:
           sarif_file: semgrep.sarif
 
+      - name: Import results into DefectDojo
+        if: always()
+        continue-on-error: true
+        env:
+          DEFECTDOJO_URL: ${{ secrets.DEFECTDOJO_URL }}
+          DEFECTDOJO_API_TOKEN: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+        run: |
+          if [ ! -s semgrep.sarif ]; then
+            echo "No semgrep.sarif file found, skipping DefectDojo import"
+            exit 0
+          fi
+          curl -sS -f \
+            -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+            -F "scan_type=SARIF" \
+            -F "file=@semgrep.sarif" \
+            -F "product_type_name=GitHub" \
+            -F "product_name=${{ github.event.repository.name }}" \
+            -F "engagement_name=CI" \
+            -F "auto_create_context=true" \
+            -F "close_old_findings=true" \
+            -F "deduplication_on_engagement=true" \
+            -F "commit_hash=${{ github.sha }}" \
+            -F "branch_tag=${{ github.head_ref || github.ref_name }}" \
+            "${DEFECTDOJO_URL}/api/v2/reimport-scan/"
+
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
         env:


### PR DESCRIPTION
### **User description**
## Summary
- Adds a non-blocking "Import results into DefectDojo" step to `.github/workflows/semgrep.yml`, run after the SARIF is generated and after the existing GitHub Code Scanning upload step.
- Reimports the SARIF into DefectDojo via `POST ${DEFECTDOJO_URL}/api/v2/reimport-scan/`, authenticated with the org-wide `DEFECTDOJO_API_TOKEN` secret, so Semgrep findings get an aggregated view in DefectDojo instead of only living in PR checks.
- Mirrors `smileidentity/lambda#4662` (merged, verified working end-to-end) — same step, same API call shape, same non-blocking (`continue-on-error: true`, `if: always()`) behavior, only difference is repo context (product/engagement names derived from this repo).

## SARIF filename
This repo's Semgrep step (`semgrep scan --config p/security-audit --sarif -o semgrep.sarif`) already writes to `semgrep.sarif`, same as `lambda`, so no filename adjustment was needed.

## Test plan
- [ ] CI run on this PR shows the new "Import results into DefectDojo" step executing (may show a curl failure if this PR's own SARIF has no findings — should still be non-blocking)
- [ ] Confirm a corresponding scan/product shows up in DefectDojo under product name `ios`, engagement `CI`
- [ ] Verify the existing SARIF-upload-to-GitHub-Security and PR-comment steps still behave as before


___

### **PR Type**
Enhancement


___

### **Description**
- Add DefectDojo SARIF reimport step to Semgrep workflow

- Non-blocking step uploads findings for aggregated visibility

- Auto-creates product/engagement context in DefectDojo

- Closes old findings and deduplicates per engagement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Semgrep Scan"] -- "generates" --> B["semgrep.sarif"]
  B -- "upload" --> C["GitHub Code Scanning"]
  B -- "reimport" --> D["DefectDojo API"]
  D -- "aggregates" --> E["DefectDojo Dashboard"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add DefectDojo reimport step to Semgrep workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>Adds a new "Import results into DefectDojo" step after the GitHub <br>SARIF upload<br> <li> Uses <code>curl</code> to POST the <code>semgrep.sarif</code> file to DefectDojo's reimport-scan <br>API<br> <li> Configured as non-blocking (<code>continue-on-error: true</code>, <code>if: always()</code>)<br> <li> Passes repo name, commit hash, branch, and deduplication settings as <br>form fields</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/498/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>