### PR TITLE
Fix Ruby json vulnerability and stop recurring Swift dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
       swift-dependencies:
         patterns:
           - '*'
+    ignore:
+      - dependency-name: "github.com/airbnb/lottie-spm"
+      - dependency-name: "github.com/fingerprintjs/fingerprintjs-ios"
+      - dependency-name: "github.com/getsentry/sentry-cocoa"
   - package-ecosystem: "bundler"
     directory: "/"
     open-pull-requests-limit: 0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.17.1.2)
+    json (2.21.1)
     logger (1.7.0)
     minitest (5.27.0)
     molinillo (0.8.0)


### PR DESCRIPTION
### **User description**
Issue: https://github.com/smileidentity/ios/issues/502

## Summary

- Bump json from 2.17.1.2 to 2.21.1 in Gemfile.lock to resolve CVE-2026-54696, which the daily Ruby security audit flagged in issue #502.
- Ignore three Swift packages in dependabot.yml whose group update PRs are closed unmerged every week: lottie-spm, fingerprintjs-ios and sentry-cocoa. They are pinned to exact versions in Package.swift, so the automated bumps are always rejected.

## Known Issues

- Ignoring all version bumps for the three Swift packages is intentional, matching the exact pins in Package.swift. Remove the ignore entries if we later decide to accept those updates.

## Test Instructions

- Run the Ruby security audit locally with `bundle exec bundler-audit check`, or trigger the Security Audit workflow. It should report no vulnerabilities.
- On the next Monday Dependabot run, confirm no swift-dependencies PR is opened for lottie-spm, fingerprintjs-ios or sentry-cocoa.

## Screenshot

<!-- TODO: add a fun gif here 🎬 -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Ignore repeatedly-closed Swift dependabot PRs for pinned packages

- Fix Ruby json vulnerability (bumped in Gemfile.lock, not shown in diff)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dependabot.yml"] -- "add ignore rules" --> B["lottie-spm"]
  A -- "add ignore rules" --> C["fingerprintjs-ios"]
  A -- "add ignore rules" --> D["sentry-cocoa"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Ignore pinned Swift packages in dependabot config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Added <code>ignore</code> entries for three Swift packages (<code>lottie-spm</code>, <br><code>fingerprintjs-ios</code>, <code>sentry-cocoa</code>) under the swift-package-manager <br>ecosystem config<br> <li> These packages are pinned to exact versions in Package.swift and their <br>automated PRs were always closed unmerged</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/507/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>