### PR TITLE
chore: update SmileID binaries to v11.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## 11.2.0 - August 7, 2026
+
+### Fixed
+* Fixed `enableCrashReporting: false` being ignored by the config-based `initialize` overload
+* Non-JSON success responses (for example from captive portals) are now treated as network failures instead of decoding errors, so they can be retried
+* Selfie submission now checks captured files exist before submitting and reports a `.fileNotFound` error naming the missing files, instead of a generic "Selfie capture failed"
+
+### Changed
+* Job submissions now also retry on error code `2206`, as they already do for `2215`.
+* Enhanced SmartSelfie active liveness now measures head pose relative to the user's neutral pose and requires re-centring between tasks, so a held pose or a phone moved around a static face can no longer pass
+* Liveness progress now accrues by holding a pose past the trigger threshold (matching Android), and the "look up" threshold is eased to roughly match Android's
+* A diagonal pose can no longer satisfy two directions at once, and progress arcs now show only during the look left, right and up prompts
+* Bumped `active_liveness_version` metadata to `2.0.0` so submissions using the new head-pose logic are distinguishable server-side
+* Sentry now reports only from production builds and production traffic, throttles to one event per error fingerprint per hour, and records server errors and non-JSON responses as breadcrumbs and tags instead of events, matching Android
+* Removed the inert `enableCrashHandler` option — crash reporting is handled-errors-only by design
+
 ## 11.1.11 - May 14, 2026
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -33,8 +33,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "SmileIDSDK",
-      url: "https://github.com/smileidentity/ios/releases/download/v11.1.11/SmileIDSDK.xcframework.zip",
-      checksum: "7b3922ba1dd1a617bbbb0a1ddacb1990625a2e7c5257dcfceb3f229ee6f8c64d"
+      url: "https://github.com/smileidentity/ios/releases/download/v11.2.0/SmileIDSDK.xcframework.zip",
+      checksum: "72dcb12072f4bb4d801d836af024c86c47905ec781579e2e4a0ad76006409797"
     )
   ]
 )

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '11.1.11'
+  s.version          = '11.2.0'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = 'SmileIDSDK'
-  s.version = '11.1.11'
+  s.version = '11.2.0'
   s.summary = 'Binary SmileID SDK module.'
   s.homepage = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license  = { :type => 'MIT' }
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   }
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.9'
-  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.1.11/SmileIDSDK-xcframeworks-v11.1.11.zip', :sha256 => 'fd91accdc13116b05938ff13912b5b7928b15228675ad0e300f58c0c799fedf8' }
+  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.2.0/SmileIDSDK-xcframeworks-v11.2.0.zip', :sha256 => '86578d7fe8849fb4b764197b6efcca98ebc5d68d33065d985ab2ca0b32c116bf' }
   s.vendored_frameworks = 'SmileIDSDK-xcframeworks/SmileIDSDK.xcframework', 'SmileIDSDK-xcframeworks/Lottie.xcframework'
 
   s.dependency 'ZIPFoundation', '0.9.20'


### PR DESCRIPTION
### **User description**
Automated update to consume the SmileID iOS SDK v11.2.0 XCFramework binaries.

- Updates Package.swift to reference the published binary targets (SmileIDSDK).
- Updates SmileIDSDK.podspec to vend the new XCFramework bundle.
- Bumps SmileID.podspec to v11.2.0.
- Prepends the v11.2.0 section into CHANGELOG.md (mirrored from the SDK's CHANGELOG.md), so the release tag points at a commit that already contains the matching release notes.

## After merging — manual follow-up: push SmileID.podspec

On merge, `release-on-merge.yml` will automatically tag the merge commit, create the public GitHub release, and `pod trunk push SmileIDSDK.podspec`. **`SmileID.podspec` is not pushed automatically** — CocoaPods Trunk's aggregate index file lags the per-version spec by 30 min – several hours, and an immediate push fails dependency validation.

**Recommended:** once `pod trunk info SmileIDSDK` lists `11.2.0` in the CDN index, trigger the **Push SmileID.podspec** workflow from the Actions tab on `smileidentity/ios`:

<https://github.com/smileidentity/ios/actions/workflows/push-smileid-podspec.yml>

Click **Run workflow** → leave the version blank (it auto-detects from `main`) → **Run workflow**. The job pre-flights the CDN-index check, so dispatching too early fails fast with a clear error instead of wasting CocoaPods validation time.

**Alternative — push locally from `main`:**

```
pod trunk push SmileID.podspec --allow-warnings
```

Quick CDN-index readiness check (returns `ready` or `not yet`):

```
hash=$(printf '%s' "SmileIDSDK" | md5)
curl -sfL "https://cdn.cocoapods.org/all_pods_versions_${hash:0:1}_${hash:1:1}_${hash:2:1}.txt" \
  | grep "^SmileIDSDK/" | grep -q 11.2.0 && echo ready || echo "not yet"
```

Generated by the ios-sdk release workflow.


___

### **PR Type**
Other, Documentation


___

### **Description**
- Bump SmileID SDK binaries to v11.2.0

- Update binary target URL and checksum

- Update podspec versions and XCFramework source

- Add v11.2.0 release notes to changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["v11.1.11"] -- "version bump" --> B["v11.2.0"]
  B --> C["Package.swift binaryTarget URL + checksum"]
  B --> D["SmileID.podspec version"]
  B --> E["SmileIDSDK.podspec version + source zip/sha256"]
  B --> F["CHANGELOG.md release notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Package.swift</strong><dd><code>Point binary target to v11.2.0 artifact</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Package.swift

<ul><li>Updated <code>SmileIDSDK</code> binary target download URL to <code>v11.2.0</code><br> <li> Updated the corresponding XCFramework checksum</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/511/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileIDSDK.podspec</strong><dd><code>Bump binary podspec to v11.2.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileIDSDK.podspec

<ul><li>Bumped <code>s.version</code> to <code>11.2.0</code><br> <li> Updated <code>s.source</code> http URL to the v11.2.0 xcframeworks zip<br> <li> Updated the <code>sha256</code> checksum for the new archive</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/511/files#diff-e2677e36ff8c7dc8b8ae5b17051961542e66ff4ef08168a7c53da75accfd55b6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileID.podspec</strong><dd><code>Bump SmileID podspec version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileID.podspec

- Bumped `s.version` from `11.1.11` to `11.2.0`


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/511/files#diff-7b77f15ea198e0bc969823c4cfbc250e2f35c075d092f421f4bffc86d00973a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add v11.2.0 release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added <code>11.2.0</code> release notes section<br> <li> Documented fixes (crash reporting flag, non-JSON responses, missing <br>selfie files)<br> <li> Documented changes (retry on <code>2206</code>, head-pose based active liveness, <br><code>active_liveness_version</code> 2.0.0, Sentry throttling, removal of <br><code>enableCrashHandler</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/511/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>