### PR TITLE
fix: drop the phantom Sentry, ZIPFoundation and FingerprintJS dependency declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Unreleased
+
+### Changed
+* Removed the Sentry, ZIPFoundation and FingerprintJS dependency declarations from the Swift
+  Package Manager and CocoaPods manifests. The SDK binary already embeds these libraries, so
+  nothing changes at runtime — apps stop downloading a second copy, and apps that also use
+  `sentry_flutter` (or pin `sentry-cocoa` themselves) can now resolve under Swift Package
+  Manager. If your own code imports `Sentry`, `ZIPFoundation` or `FingerprintJS` without
+  declaring the dependency, add it to your project — it no longer arrives through this SDK.
+
 ## 11.2.0 - August 7, 2026
 
 ### Fixed

--- a/Example/SmileID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SmileID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "6b6e341078abbdf309ac64e2174705810b6fb8ade383f0877af402b4dde55304",
+  "originHash" : "62bf0de6c631832f6f06f207274a953819dbd63a81d066e284e67d9668d5d79d",
   "pins" : [
-    {
-      "identity" : "fingerprintjs-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/fingerprintjs/fingerprintjs-ios",
-      "state" : {
-        "revision" : "2e2ead3d02c46736d9b4a66373700489113e293a",
-        "version" : "1.6.0"
-      }
-    },
     {
       "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
@@ -26,24 +17,6 @@
       "state" : {
         "revision" : "557576032736fd3140422baefb68b8f76c55088f",
         "version" : "1.21.0"
-      }
-    },
-    {
-      "identity" : "sentry-cocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getsentry/sentry-cocoa",
-      "state" : {
-        "revision" : "8627bbc0e663238d516b541d8fc7edd62a627fde",
-        "version" : "8.57.3"
-      }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
-        "version" : "0.9.20"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,39 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "fingerprintjs-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/fingerprintjs/fingerprintjs-ios",
-      "state" : {
-        "revision" : "2e2ead3d02c46736d9b4a66373700489113e293a",
-        "version" : "1.6.0"
-      }
-    },
-    {
       "identity" : "lottie-spm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm",
       "state" : {
         "revision" : "04f2fd18cc9404a0a0917265a449002674f24ec9",
         "version" : "4.5.2"
-      }
-    },
-    {
-      "identity" : "sentry-cocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getsentry/sentry-cocoa",
-      "state" : {
-        "revision" : "e9bcb13a491c00da6c9d100fe73954aea9e9d8a6",
-        "version" : "8.57.0"
-      }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
-        "version" : "0.9.20"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,20 +13,17 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/weichsel/ZIPFoundation.git", exact: "0.9.20"),
-    .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2"),
-    .package(url: "https://github.com/fingerprintjs/fingerprintjs-ios", exact: "1.6.0"),
-    .package(url: "https://github.com/getsentry/sentry-cocoa", exact: "8.57.3")
+    // Lottie is the one real external dependency: SmileIDSDK dynamically links
+    // @rpath/Lottie.framework, so the consumer's package graph must supply it,
+    // and the exact pin must match the version the binary was built against.
+    .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2")
   ],
   targets: [
     .target(
       name: "SmileID",
       dependencies: [
         "SmileIDSDK",
-        .product(name: "ZIPFoundation", package: "ZIPFoundation"),
-        .product(name: "Lottie", package: "lottie-spm"),
-        .product(name: "FingerprintJS", package: "fingerprintjs-ios"),
-        .product(name: "Sentry", package: "sentry-cocoa")
+        .product(name: "Lottie", package: "lottie-spm")
       ],
       path: "Sources",
       sources: ["Classes"]

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    // Lottie is the one real external dependency: SmileIDSDK dynamically links
-    // @rpath/Lottie.framework, so the consumer's package graph must supply it,
-    // and the exact pin must match the version the binary was built against.
+    // SmileIDSDK dynamically links Lottie; the pin must match the version the binary was built against.
     .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2")
   ],
   targets: [

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -16,10 +16,6 @@ Pod::Spec.new do |s|
   s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.2.0/SmileIDSDK-xcframeworks-v11.2.0.zip', :sha256 => '86578d7fe8849fb4b764197b6efcca98ebc5d68d33065d985ab2ca0b32c116bf' }
   s.vendored_frameworks = 'SmileIDSDK-xcframeworks/SmileIDSDK.xcframework', 'SmileIDSDK-xcframeworks/Lottie.xcframework'
 
-  s.dependency 'ZIPFoundation', '0.9.20'
-  s.dependency 'FingerprintJS', '1.6.0'
-  s.dependency 'Sentry', '~> 8.57'
-
   s.pod_target_xcconfig = {
     'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
   }


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

![gif](https://media4.giphy.com/media/v1.Y2lkPWYwNzlmZTI2eXU0dzJiOWQ2M2I5ZHF6NG0yazY0amtoODJvbW15anJ5aGtpMHo3ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/fVyWazTQXeJTZF1MBq/giphy.gif)

## Summary

Removes the Sentry, ZIPFoundation and FingerprintJS dependency declarations from `Package.swift` and `SmileIDSDK.podspec` — the shipped binary already embeds all three (zero undefined symbols from them), so the declarations only force partners to build a second copy and break SwiftPM resolution for any app that pins `sentry-cocoa` differently (`sentry_flutter` being the common case, reproduced and fixed by this change). Lottie stays pinned exact: it is dynamically linked and genuinely consumer-supplied.

## Known Issues

Do not release until the paired `ios-sdk` changes land: `SmileIDSDK`'s `PrivacyInfo.xcprivacy` must declare the required-reason APIs currently covered by the deleted packages' manifests, and `sdk-release.yml`'s two Sentry version-rewrite steps need removing. Release notes must mention that apps relying on transitive `import Sentry`/`import ZIPFoundation` now need their own declaration. Minor release, never a patch.

## Test Instructions

`swift package resolve` (graph is now Lottie + binary only). Verified with the Flutter wrapper on this branch: previously-unresolvable `sentry_flutter` app now builds; sample app builds; archive drops the duplicate `Sentry.framework`; simulator run renders all SDK screens.

## Screenshot

N/A — dependency manifests only.
