### PR TITLE
chore: update SmileID binaries to v11.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 11.2.2 - September 10, 2026
+
+### Fixed
+* Fixed SmartSelfie™ captures occasionally submitting the same liveness picture twice, which failed the job. Every liveness image is now a different frame.
+
 ## 11.2.1 - August 14, 2026
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "SmileIDSDK",
-      url: "https://github.com/smileidentity/ios/releases/download/v11.2.1/SmileIDSDK.xcframework.zip",
-      checksum: "108ffc595d135d31de4f8731f76d37fd5df0a816affb92206e6ebedd84cb8f36"
+      url: "https://github.com/smileidentity/ios/releases/download/v11.2.2/SmileIDSDK.xcframework.zip",
+      checksum: "2e461421aa95b54ed4531872df207167d86f85c94f7d2184a3208932ff247baf"
     )
   ]
 )

--- a/SmileID.podspec
+++ b/SmileID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SmileID'
-  s.version          = '11.2.1'
+  s.version          = '11.2.2'
   s.summary          = 'The Official Smile Identity iOS SDK.'
   s.homepage         = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SmileIDSDK.podspec
+++ b/SmileIDSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = 'SmileIDSDK'
-  s.version = '11.2.1'
+  s.version = '11.2.2'
   s.summary = 'Binary SmileID SDK module.'
   s.homepage = 'https://docs.usesmileid.com/integration-options/mobile/getting-started'
   s.license  = { :type => 'MIT' }
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   }
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.9'
-  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.2.1/SmileIDSDK-xcframeworks-v11.2.1.zip', :sha256 => '0e8243004c1e49b344cf77112678e3750cb5c80470bc8c8265ba296a5e50d40a' }
+  s.source = { :http => 'https://github.com/smileidentity/ios/releases/download/v11.2.2/SmileIDSDK-xcframeworks-v11.2.2.zip', :sha256 => '771b2f06f0912a1c0248833325067204ea752327eddf9bd4a144d645c73c0632' }
   s.vendored_frameworks = 'SmileIDSDK-xcframeworks/SmileIDSDK.xcframework', 'SmileIDSDK-xcframeworks/Lottie.xcframework'
 
   s.pod_target_xcconfig = {


### PR DESCRIPTION
### **User description**
Automated update to consume the SmileID iOS SDK v11.2.2 XCFramework binaries.

- Updates Package.swift to reference the published binary targets (SmileIDSDK).
- Updates SmileIDSDK.podspec to vend the new XCFramework bundle.
- Bumps SmileID.podspec to v11.2.2.
- Prepends the v11.2.2 section into CHANGELOG.md (mirrored from the SDK's CHANGELOG.md), so the release tag points at a commit that already contains the matching release notes.

## After merging — manual follow-up: push SmileID.podspec

On merge, `release-on-merge.yml` will automatically tag the merge commit, create the public GitHub release, and `pod trunk push SmileIDSDK.podspec`. **`SmileID.podspec` is not pushed automatically** — CocoaPods Trunk's aggregate index file lags the per-version spec by 30 min – several hours, and an immediate push fails dependency validation.

**Recommended:** once `pod trunk info SmileIDSDK` lists `11.2.2` in the CDN index, trigger the **Push SmileID.podspec** workflow from the Actions tab on `smileidentity/ios`:

<https://github.com/smileidentity/ios/actions/workflows/push-smileid-podspec.yml>

Click **Run workflow** → leave the version blank (it auto-detects from `main`) → **Run workflow**. The job pre-flights the CDN-index check, so dispatching too early fails fast with a clear error instead of wasting CocoaPods validation time.

**Alternative — push locally from `main`:**

```
pod trunk push SmileID.podspec --allow-warnings
```

Quick CDN-index readiness check (returns `ready` or `not yet`):

```
hash=$(printf '%s' "SmileIDSDK" | md5)
curl -sfL "https://cdn.cocoapods.org/all_pods_versions_${hash:0:1}_${hash:1:1}_${hash:2:1}.txt" \
  | grep "^SmileIDSDK/" | grep -q 11.2.2 && echo ready || echo "not yet"
```

Generated by the ios-sdk release workflow.


___

### **PR Type**
Other


___

### **Description**
- Bump SmileID SDK binaries to v11.2.2

- Update XCFramework URLs and checksums

- Bump both podspec versions to 11.2.2

- Add v11.2.2 changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["v11.2.1 release artifacts"] -- "version bump" --> B["v11.2.2 release artifacts"]
  B --> C["Package.swift binaryTarget"]
  B --> D["SmileIDSDK.podspec source"]
  B --> E["SmileID.podspec version"]
  B --> F["CHANGELOG.md entry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Package.swift</strong><dd><code>Point binary target to v11.2.2 XCFramework</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Package.swift

<ul><li>Updated <code>SmileIDSDK</code> binary target URL to the v11.2.2 XCFramework zip<br> <li> Updated the corresponding binary checksum</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/520/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileIDSDK.podspec</strong><dd><code>Vend v11.2.2 XCFrameworks bundle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileIDSDK.podspec

<ul><li>Bumped <code>s.version</code> to <code>11.2.2</code><br> <li> Updated HTTP source URL and sha256 for the v11.2.2 XCFrameworks bundle</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/520/files#diff-e2677e36ff8c7dc8b8ae5b17051961542e66ff4ef08168a7c53da75accfd55b6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmileID.podspec</strong><dd><code>Bump SmileID podspec version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

SmileID.podspec

- Bumped `s.version` from `11.2.1` to `11.2.2`


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/520/files#diff-7b77f15ea198e0bc969823c4cfbc250e2f35c075d092f421f4bffc86d00973a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add v11.2.2 release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Prepended 11.2.2 release notes section<br> <li> Documented fix for duplicate liveness images in SmartSelfie captures</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/520/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>