### PR TITLE
🩹 ci: read s.version with POSIX awk so the podspec push works on the macOS runner

### DIFF
--- a/.github/workflows/push-smileid-podspec.yml
+++ b/.github/workflows/push-smileid-podspec.yml
@@ -48,7 +48,7 @@ jobs:
           if [[ -n "${INPUT_VERSION}" ]]; then
             version="${INPUT_VERSION}"
           else
-            version="$(awk -F\' '/^\s*s\.version\s*=/ { print $2; exit }' SmileID.podspec)"
+            version="$(awk -F\' '/^[[:space:]]*s\.version[[:space:]]*=/ { print $2; exit }' SmileID.podspec)"
           fi
           if [[ -z "${version}" ]]; then
             echo "::error::Could not determine version (no input and SmileID.podspec has no s.version line)"


### PR DESCRIPTION
### **User description**
Story: https://app.shortcut.com/smileid/story/xxx

![fix](https://media1.giphy.com/media/v1.Y2lkPTM4ZDczMDY1NWthc3hxZzFpZmtpd2pxbTA4dnR6Yzc4b2l1N2NsNGVkZGN0ZDJ5ZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ILVQK9gcdtIoPJEF4K/giphy.gif)

## Summary

Dispatching "Push SmileID.podspec" with the version left blank fails immediately:

```
Could not determine version (no input and SmileID.podspec has no s.version line)
```

`SmileID.podspec` does have one — `s.version = '11.2.2'` on line 3. The step reads it with

```
awk -F\' '/^\s*s\.version\s*=/ { print $2; exit }' SmileID.podspec
```

and `\s` is a GNU awk extension. This job runs on `macos-15`, where `awk` is the one true
awk and does not support `\s`, so the pattern never matches. Swapped for the POSIX
`[[:space:]]`.

Reproduced on macOS awk 20200816 against the real podspec: the `\s` form returns an empty
string, the `[[:space:]]` form returns `11.2.2`.

## Known Issues

It went unnoticed because passing `version` explicitly skips the branch entirely, and the
workflow had not been run with the input blank. The 11.2.2 push is unblocked by passing the
version by hand, so this is about the next release rather than this one.

Same class of problem as the release run's permissions failure earlier today: a release-path
step that no release had exercised. Nothing here is covered by a pre-merge gate, so a shell
mistake stays invisible until someone cuts a release.

## Test Instructions

On macOS, against the podspec at the repo root:

```
awk -F\' '/^[[:space:]]*s\.version[[:space:]]*=/ { print $2; exit }' SmileID.podspec
# -> 11.2.2

awk -F\' '/^\s*s\.version\s*=/ { print $2; exit }' SmileID.podspec
# -> (empty, the bug)
```

End to end, the real check is dispatching the workflow with `version` blank once the CDN has
indexed the dependency — the step should print `Pushing SmileID v<version>` instead of
erroring.

## Screenshot

N/A — CI configuration only.

🩹


___

### **PR Type**
Bug fix


___

### **Description**
- Replace GNU-only `\s` with POSIX `[[:space:]]` in awk

- Fixes version extraction from `SmileID.podspec` on macOS runner

- Unblocks blank-version dispatch of podspec push workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["blank version input"] --> B["awk regex on SmileID.podspec"]
  B -- "before: \s (GNU-only) → no match" --> C["error: no s.version line"]
  B -- "after: [[:space:]] (POSIX)" --> D["version resolved (e.g. 11.2.2)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>push-smileid-podspec.yml</strong><dd><code>Use POSIX character class in awk version lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/push-smileid-podspec.yml

<ul><li>Changed the awk pattern used to read <code>s.version</code> from <code>SmileID.podspec</code>.<br> <li> Swapped GNU awk extension <code>\s</code> for POSIX <code>[[:space:]]</code>, which macOS awk <br>supports.<br> <li> Allows the workflow to auto-detect the version when the <code>version</code> input <br>is left blank.</ul>


</details>


  </td>
  <td><a href="https://github.com/smileidentity/ios/pull/521/files#diff-4022d6c4ad1278aea7ce1068cb2be5615510838a3198639f303604ec99222d7d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>